### PR TITLE
update DoxyGen version to 1.9.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: Open-CMSIS-Pack/gen-pack-action@main
         with:
-          doxygen-version: 1.9.2
+          doxygen-version: 1.9.5
           packchk-version: 1.3.95
           gen-doc-script: ./DoxyGen/gen_doc.sh
           check-links-script: |

--- a/DoxyGen/gen_doc.sh
+++ b/DoxyGen/gen_doc.sh
@@ -22,7 +22,7 @@
 #
 # Pre-requisites:
 # - bash shell (for Windows: install git for Windows)
-# - doxygen 1.9.2
+# - doxygen 1.9.5
 # - git
 # - gh cli
 
@@ -30,7 +30,7 @@ set -o pipefail
 
 DIRNAME=$(dirname $(realpath $0))
 DOXYGEN=$(which doxygen)
-REQ_DXY_VERSION="1.9.2"
+REQ_DXY_VERSION="1.9.5"
 REQUIRED_GEN_PACK_LIB="0.5.1"
 
 ############ gen-pack library ###########

--- a/DoxyGen/nn.dxy.in
+++ b/DoxyGen/nn.dxy.in
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Doxyfile 1.9.2
+# Doxyfile 1.9.5
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.


### PR DESCRIPTION
As per the title, this fix will resolve the [Build Pack failure](https://github.com/ARM-software/CMSIS-NN/actions). Note that here are still some autogenerated files with the old version, that we will keep an eye on to make sure they are up to date too:

```
DoxyGen/templates/tabs.css
DoxyGen/templates/header.html
DoxyGen/templates/Layout_forUser.xml
```