### PR TITLE
Delete wrong line in doc

### DIFF
--- a/Include/arm_nnfunctions.h
+++ b/Include/arm_nnfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        7 November 2022
- * $Revision:    V.11.2.0
+ * $Date:        21 November 2022
+ * $Revision:    V.11.2.1
  *
  * Target Processor:  Arm Cortex-M Processors
  * -------------------------------------------------------------------- */

--- a/Include/arm_nnfunctions.h
+++ b/Include/arm_nnfunctions.h
@@ -432,7 +432,6 @@ int32_t arm_convolve_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, c
  * @details
  *   - Supported framework : TensorFlow Lite Micro
  *   - The following constrains on the arguments apply
- *      -# input_dims->c is a multiple of 4
  *      -# conv_params->padding.w = conv_params->padding.h = 0
  *      -# conv_params->stride.w = conv_params->stride.h = 1
  *


### PR DESCRIPTION
The comment for `arm_convolve_1x1_s8_fast` in `arm_nnfunctions.h` deviates from what is required in the [code](https://github.com/ARM-software/CMSIS_5/blob/7f6a7b6b870dbb990b65868f7f54cc2a6dab41e1/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c#L63). 
```
...
 if (conv_params->padding.w != 0 || conv_params->padding.h != 0 || conv_params->stride.w != 1 ||
        conv_params->stride.h != 1)
    {
        return ARM_CMSIS_NN_ARG_ERROR;
    }
...
```

It mentions that `input_dims` has to be a multiple of 4 but the code does not have this restriction. 


FYI: @SebastianBoblest @UlrikHjort @vdkhoi

Previous PR: https://github.com/ARM-software/CMSIS_5/pull/1591