### PR TITLE
Workaround for GNU Toolchain 12.x bug

### DIFF
--- a/Include/arm_nn_math_types.h
+++ b/Include/arm_nn_math_types.h
@@ -16,13 +16,16 @@
  * limitations under the License.
  */
 
-/******************************************************************************
- * @file     arm_nn_math_types.h
- * @brief    Compiler include and basic types
- * @version  V1.2.1
- * @date     26 October 2022
- * Target Processor: Cortex-M
- ******************************************************************************/
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_nn_math_types.h
+ * Description:  Compiler include and basic types
+ *
+ * $Date:        23 December 2022
+ * $Revision:    V.1.2.2
+ *
+ * Target Processor:  Arm Cortex-M CPUs
+ * -------------------------------------------------------------------- */
 
 /**
    Copied from CMSIS/DSP/arm_math_types.h and modified
@@ -110,7 +113,12 @@ extern "C" {
 #elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
 
 #elif defined(__GNUC__)
-// #pragma GCC diagnostic pop
+
+#if (__GNUC__ == 12 && (__GNUC_MINOR__ <= 2))
+// Workaround for Internal Compiler Error for GCC 12.2.x
+// https://gcc.gnu.org/pipermail/gcc-patches/2022-December/607963.html
+#define ARM_GCC_12_2_ICE
+#endif
 
 #elif defined(__ICCARM__)
 

--- a/Source/SoftmaxFunctions/arm_softmax_s8.c
+++ b/Source/SoftmaxFunctions/arm_softmax_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_softmax_s8.c
  * Description:  S8 softmax function
  *
- * $Date:        9 March 2022
- * $Revision:    V.2.1.0
+ * $Date:        23 December 2022
+ * $Revision:    V.2.1.1
  *
  * Target Processor:  Cortex-M cores
  *

--- a/Source/SoftmaxFunctions/arm_softmax_s8.c
+++ b/Source/SoftmaxFunctions/arm_softmax_s8.c
@@ -33,7 +33,7 @@
 
 #define ACCUM_BITS 12
 
-#ifdef ARM_MATH_MVEI
+#if defined(ARM_MATH_MVEI) && !defined(ARM_GCC_12_2_ICE)
 static int32x4_t arm_exp_on_negative_values_mve_32x4(int32x4_t val)
 {
 #define SHIFT_START (24)
@@ -91,7 +91,7 @@ void arm_softmax_s8(const int8_t *input,
                     const int32_t diff_min,
                     int8_t *output)
 {
-#ifdef ARM_MATH_MVEI
+#if defined(ARM_MATH_MVEI) && !defined(ARM_GCC_12_2_ICE)
 
 #define ACT_MIN ((int8_t)NN_Q7_MIN)
 #define ACT_MAX ((int8_t)NN_Q7_MAX)


### PR DESCRIPTION
Arm GCC toolchain 12.x generates a crash in
arm_softmax_s8() for Arm Cortex-M55 and Cortex-M85. MVE optimizations are disabled for the 12.x versions of the compiler.

