### PR TITLE
Remove dependency to CMSIS-Core

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+# SPDX-FileCopyrightText: Copyright 2010-2021, 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -27,6 +27,7 @@ AlignOperands:   false
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 BinPackArguments: false
+IndentPPDirectives: BeforeHash
 BinPackParameters: false
 BraceWrapping:
   AfterClass:      false

--- a/ARM.CMSIS-NN.pdsc
+++ b/ARM.CMSIS-NN.pdsc
@@ -13,6 +13,15 @@
     </release>
   </releases>
 
+  <!-- conditions are dependency rules that can apply to a component or an individual file -->
+  <conditions>
+    <!-- CMSIS-NN -->
+    <condition id="CMSIS-NN">
+      <description>No additional components required for CMSIS-NN</description>
+    </condition>
+  </conditions>
+
+
   <components>
     <!-- CMSIS-NN component -->
     <component Cclass="CMSIS" Cgroup="NN Lib" Cversion="0.0.0" condition="CMSIS-NN">

--- a/ARM.CMSIS-NN.pdsc
+++ b/ARM.CMSIS-NN.pdsc
@@ -13,15 +13,6 @@
     </release>
   </releases>
 
-  <!-- conditions are dependency rules that can apply to a component or an individual file -->
-  <conditions>
-    <!-- CMSIS-NN -->
-    <condition id="CMSIS-NN">
-      <description>Components required for CMSIS-NN</description>
-      <require Cclass="CMSIS" Cgroup="CORE"/>
-    </condition>
-  </conditions>
-
   <components>
     <!-- CMSIS-NN component -->
     <component Cclass="CMSIS" Cgroup="NN Lib" Cversion="0.0.0" condition="CMSIS-NN">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,12 +19,6 @@
 cmake_minimum_required(VERSION 3.15.6)
 
 project(CMSISNN)
-
-set(CMSIS_PATH "</path/to/CMSIS>" CACHE PATH "Path to CMSIS.")
-
-if (${CMSIS_PATH} STREQUAL "</path/to/CMSIS>")
-  message(FATAL_ERROR "CMSIS_PATH not set. Did you provide -DCMSIS_PATH=<path/to/CMSIS>?")
-endif()
 
 add_library(cmsis-nn STATIC)
 

--- a/Include/Internal/arm_nn_compiler.h
+++ b/Include/Internal/arm_nn_compiler.h
@@ -54,24 +54,6 @@
         #define __RESTRICT __restrict
     #endif
 
-#elif defined(__GNUC__)
-
-    #ifndef __ASM
-        #define __ASM __asm
-    #endif
-    #ifndef __INLINE
-        #define __INLINE inline
-    #endif
-    #ifndef __STATIC_INLINE
-        #define __STATIC_INLINE static inline
-    #endif
-    #ifndef __STATIC_FORCEINLINE
-        #define __STATIC_FORCEINLINE __attribute__((always_inline)) static inline
-    #endif
-    #ifndef __RESTRICT
-        #define __RESTRICT __restrict
-    #endif
-
 #elif defined(__ICCARM__)
 
     #warning IAR support is not tested
@@ -104,6 +86,24 @@
     #endif
     #ifndef __ALIGNED
         #define __ALIGNED(x) __declspec(align(x))
+    #endif
+
+#elif defined(__GNUC__)
+
+    #ifndef __ASM
+        #define __ASM __asm
+    #endif
+    #ifndef __INLINE
+        #define __INLINE inline
+    #endif
+    #ifndef __STATIC_INLINE
+        #define __STATIC_INLINE static inline
+    #endif
+    #ifndef __STATIC_FORCEINLINE
+        #define __STATIC_FORCEINLINE __attribute__((always_inline)) static inline
+    #endif
+    #ifndef __RESTRICT
+        #define __RESTRICT __restrict
     #endif
 
 #else

--- a/Include/Internal/arm_nn_compiler.h
+++ b/Include/Internal/arm_nn_compiler.h
@@ -1,0 +1,306 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_nn_compiler.h
+ * Description:  Generic compiler header
+ *
+ * $Date:        4 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ * -------------------------------------------------------------------- */
+
+#ifndef ARM_NN_COMPILER_H
+#define ARM_NN_COMPILER_H
+
+/**
+ *
+ * @brief Arm C-Language Extension(ACLE) Includes
+ *
+ */
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+
+    #ifndef __ASM
+        #define __ASM __asm
+    #endif
+    #ifndef __INLINE
+        #define __INLINE __inline
+    #endif
+    #ifndef __STATIC_INLINE
+        #define __STATIC_INLINE static __inline
+    #endif
+    #ifndef __STATIC_FORCEINLINE
+        #define __STATIC_FORCEINLINE __attribute__((always_inline)) static __inline
+    #endif
+    #ifndef __RESTRICT
+        #define __RESTRICT __restrict
+    #endif
+
+#elif defined(__GNUC__)
+
+    #ifndef __ASM
+        #define __ASM __asm
+    #endif
+    #ifndef __INLINE
+        #define __INLINE inline
+    #endif
+    #ifndef __STATIC_INLINE
+        #define __STATIC_INLINE static inline
+    #endif
+    #ifndef __STATIC_FORCEINLINE
+        #define __STATIC_FORCEINLINE __attribute__((always_inline)) static inline
+    #endif
+    #ifndef __RESTRICT
+        #define __RESTRICT __restrict
+    #endif
+
+#elif defined(__ICCARM__)
+
+    #warning IAR support is not tested
+    #ifndef __ASM
+        #define __ASM __asm
+    #endif
+    #ifndef __INLINE
+        #define __INLINE inline
+    #endif
+    #ifndef __STATIC_INLINE
+        #define __STATIC_INLINE static inline
+    #endif
+    #ifndef __FORCEINLINE
+        #define __FORCEINLINE _Pragma("inline=forced")
+    #endif
+    #ifndef __STATIC_FORCEINLINE
+        #define __STATIC_FORCEINLINE __FORCEINLINE __STATIC_INLINE
+    #endif
+
+#elif defined(_MSC_VER)
+
+    // Build for non Arm Cortex-M processors is not tested or supported.
+    // Use this section to stub any macros or intrinsics
+    #warning Unsupported compiler
+    #ifndef __STATIC_FORCEINLINE
+        #define __STATIC_FORCEINLINE static __forceinline
+    #endif
+    #ifndef __STATIC_INLINE
+        #define __STATIC_INLINE static __inline
+    #endif
+    #ifndef __ALIGNED
+        #define __ALIGNED(x) __declspec(align(x))
+    #endif
+
+#else
+
+    #error Unsupported compiler. Add support as needed
+
+#endif
+
+/**
+ *
+ * @brief Compiler specific diagnostic adjustment / fixes if applicable
+ *
+ */
+
+// Note: __ARM_ARCH is used with M-profile architecture as the target here.
+#if defined(__GNUC__)
+    #if (__GNUC__ == 12 && (__GNUC_MINOR__ <= 2)) && defined(__ARM_ARCH)
+        // Workaround for 'Internal Compiler Error' on Arm GNU Toolchain rel 12.2.x
+        // https://gcc.gnu.org/pipermail/gcc-patches/2022-December/607963.html
+        #define ARM_GCC_12_2_ICE
+    #endif
+#endif
+
+#if ((__ARM_FEATURE_MVE & 3) == 3) || (__ARM_FEATURE_MVE & 1)
+    #include <arm_mve.h>
+#endif
+
+#if defined(__ARM_ARCH) || defined(__ARM_ACLE)
+    #include <arm_acle.h>
+#endif
+
+/**
+ *
+ * @brief ACLE and Intrinsics
+ *
+ */
+
+// Note: Have __GNUC__, that is used to check for GCC , checks at the end
+// as __GNUC__ is defined by non-GCC compilers as well
+
+/* Common intrinsics for all architectures */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) || defined(__ICCARM__)
+    #define CLZ __clz
+#elif defined(__GNUC__)
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+__STATIC_FORCEINLINE uint8_t CLZ(uint32_t value)
+{
+    /* Even though __builtin_clz produces a CLZ instruction on ARM, formally
+       __builtin_clz(0) is undefined behaviour, so handle this case specially.
+       This guarantees Arm-compatible results if compiling on a non-Arm
+       target, and ensures the compiler doesn't decide to activate any
+       optimisations using the logic "value was passed to __builtin_clz, so it
+       is non-zero".
+       ARM GCC 7.3 and possibly earlier will optimise this test away, leaving a
+       single CLZ instruction.
+     */
+    if (value == 0U)
+    {
+        return 32U;
+    }
+    return __builtin_clz(value);
+}
+#endif
+
+// ACLE intrinsics under groups __ARM_FEATURE_QBIT, __ARM_FEATURE_DSP , __ARM_FEATURE_SAT, __ARM_FEATURE_SIMD32
+
+// Note: Just __ARM_FEATURE_DSP is checked to collect all intrinsics from the above mentioned groups
+
+#if (defined(__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+
+    // Common intrinsics
+    #define SMLABB __smlabb
+    #define SMLATT __smlatt
+    #define QADD __qadd
+    #define SADD16 __sadd16
+
+    // Compiler specifc variants of intrinsics. Create a new section or file for IAR if needed
+    #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) || defined(__ICCARM__)
+
+        #define SMULBB __smulbb
+        #define SMULTT __smultt
+        #define ROR __ror
+        #define SXTB16 __sxtb16
+        #define SXTAB16 __sxtab16
+        #define SXTB16_RORn(ARG1, ARG2) SXTB16(ROR(ARG1, ARG2))
+        #define SXTAB16_RORn(ARG1, ARG2, ARG3) SXTAB16(ARG1, ROR(ARG2, ARG3))
+        #define SMLAD __smlad
+        // PKH<XY> translates into pkh<xy> on AC6
+        #define PKHBT(ARG1, ARG2, ARG3)                                                                                \
+            (((((uint32_t)(ARG1))) & 0x0000FFFFUL) | ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL))
+        #define PKHTB(ARG1, ARG2, ARG3)                                                                                \
+            (((((uint32_t)(ARG1))) & 0xFFFF0000UL) | ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL))
+
+    #elif defined(__GNUC__)
+
+        #define PKHBT(ARG1, ARG2, ARG3)                                                                                \
+            __extension__({                                                                                            \
+                uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2);                                                      \
+                __ASM("pkhbt %0, %1, %2, lsl %3" : "=r"(__RES) : "r"(__ARG1), "r"(__ARG2), "I"(ARG3));                 \
+                __RES;                                                                                                 \
+            })
+        #define PKHTB(ARG1, ARG2, ARG3)                                                                                \
+            __extension__({                                                                                            \
+                uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2);                                                      \
+                if (ARG3 == 0)                                                                                         \
+                    __ASM("pkhtb %0, %1, %2" : "=r"(__RES) : "r"(__ARG1), "r"(__ARG2));                                \
+                else                                                                                                   \
+                    __ASM("pkhtb %0, %1, %2, asr %3" : "=r"(__RES) : "r"(__ARG1), "r"(__ARG2), "I"(ARG3));             \
+                __RES;                                                                                                 \
+            })
+
+__STATIC_FORCEINLINE uint32_t SXTAB16(uint32_t op1, uint32_t op2)
+{
+    uint32_t result;
+
+    __ASM("sxtab16 %0, %1, %2" : "=r"(result) : "r"(op1), "r"(op2));
+    return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t SXTB16(uint32_t op1)
+{
+    uint32_t result;
+
+    __ASM("sxtb16 %0, %1" : "=r"(result) : "r"(op1));
+    return (result);
+}
+
+// __smlad is defined by GCC, but results in a performance drop(Tested on Arm GNU Toolchain version 11.x and 12.x)
+__STATIC_FORCEINLINE uint32_t SMLAD(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+    uint32_t result;
+
+    __ASM volatile("smlad %0, %1, %2, %3" : "=r"(result) : "r"(op1), "r"(op2), "r"(op3));
+    return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t ROR(uint32_t op1, uint32_t op2)
+{
+    op2 %= 32U;
+    if (op2 == 0U)
+    {
+        return op1;
+    }
+    return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+__STATIC_FORCEINLINE uint32_t SXTB16_RORn(uint32_t op1, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtb16 %0, %1, ROR %2" : "=r"(result) : "r"(op1), "i"(rotate));
+    }
+    else
+    {
+        result = SXTB16(ROR(op1, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE uint32_t SXTAB16_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtab16 %0, %1, %2, ROR %3" : "=r"(result) : "r"(op1), "r"(op2), "i"(rotate));
+    }
+    else
+    {
+        result = SXTAB16(op1, ROR(op2, rotate));
+    }
+    return result;
+}
+
+// Inline assembly routines for ACLE intrinsics that are not defined by GCC toolchain
+__STATIC_FORCEINLINE uint32_t SMULBB(uint32_t op1, uint32_t op2)
+{
+    uint32_t result;
+
+    __ASM volatile("smulbb %0, %1, %2" : "=r"(result) : "r"(op1), "r"(op2));
+    return (result);
+}
+
+__STATIC_FORCEINLINE uint32_t SMULTT(uint32_t op1, uint32_t op2)
+{
+    uint32_t result;
+
+    __ASM volatile("smultt %0, %1, %2" : "=r"(result) : "r"(op1), "r"(op2));
+    return (result);
+}
+    #endif
+
+#endif
+
+#endif /* #ifndef ARM_NN_COMPILER_H */

--- a/Include/arm_nn_math_types.h
+++ b/Include/arm_nn_math_types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,158 +21,47 @@
  * Title:        arm_nn_math_types.h
  * Description:  Compiler include and basic types
  *
- * $Date:        28 December 2022
+ * $Date:        4 January 2023
  * $Revision:    V.1.3.2
  *
- * Target Processor:  Arm Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
-/**
-   Copied from CMSIS/DSP/arm_math_types.h and modified
-*/
+#ifndef ARM_NN_MATH_TYPES_H
 
-#ifndef _ARM_NN_MATH_TYPES_H_
+#define ARM_NN_MATH_TYPES_H
 
-#define _ARM_NN_MATH_TYPES_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <float.h>
 #include <limits.h>
-#include <math.h>
 #include <stdint.h>
 #include <string.h>
 
-/* Compiler specific diagnostic adjustment */
-#if defined(__CC_ARM)
-
-#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-
-#elif defined(__GNUC__)
-
-#elif defined(__ICCARM__)
-
-#elif defined(__TI_ARM__)
-
-#elif defined(__CSMC__)
-
-#elif defined(__TASKING__)
-
-#elif defined(_MSC_VER)
-
-#else
-#error Unknown compiler
-#endif
-
-/* Included for instrinsics definitions */
-#if defined(_MSC_VER)
-#ifndef __STATIC_FORCEINLINE
-#define __STATIC_FORCEINLINE static __forceinline
-#endif
-#ifndef __STATIC_INLINE
-#define __STATIC_INLINE static __inline
-#endif
-#ifndef __ALIGNED
-#define __ALIGNED(x) __declspec(align(x))
-#endif
-
-#elif defined(__GNUC_PYTHON__)
-#ifndef __ALIGNED
-#define __ALIGNED(x) __attribute__((aligned(x)))
-#endif
-#ifndef __STATIC_FORCEINLINE
-#define __STATIC_FORCEINLINE static inline __attribute__((always_inline))
-#endif
-#ifndef __STATIC_INLINE
-#define __STATIC_INLINE static inline
-#endif
-
-#else
-#include "cmsis_compiler.h"
-#include <arm_acle.h>
-#endif
-
-/* evaluate ARM DSP feature */
-#if (defined(__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
-#ifndef ARM_MATH_DSP
-#define ARM_MATH_DSP 1
-#endif
-#endif
-
-#if __ARM_FEATURE_MVE
-#ifndef ARM_MATH_MVEI
-#define ARM_MATH_MVEI
-#endif
-#endif
-
-/* Compiler specific diagnostic adjustment */
-#if defined(__CC_ARM)
-
-#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-
-#define ACLE_SMULBB __smulbb
-#define ACLE_SMULTT __smultt
-
-#elif defined(__GNUC__)
-
-#if (__GNUC__ == 12 && (__GNUC_MINOR__ <= 2))
-// Workaround for Internal Compiler Error for GCC 12.2.x
-// https://gcc.gnu.org/pipermail/gcc-patches/2022-December/607963.html
-#define ARM_GCC_12_2_ICE
-#endif
-
-#if defined(ARM_MATH_DSP)
-
-// Inline assembly routines for ACLE intrinsics that are not defined by GCC toolchain
-__STATIC_FORCEINLINE uint32_t ACLE_SMULBB(uint32_t op1, uint32_t op2)
-{
-    uint32_t result;
-
-    __ASM volatile("smulbb %0, %1, %2" : "=r"(result) : "r"(op1), "r"(op2));
-    return (result);
-}
-
-__STATIC_FORCEINLINE uint32_t ACLE_SMULTT(uint32_t op1, uint32_t op2)
-{
-    uint32_t result;
-
-    __ASM volatile("smultt %0, %1, %2" : "=r"(result) : "r"(op1), "r"(op2));
-    return (result);
-}
-
-#endif
-
-#elif defined(__ICCARM__)
-#define ACLE_SMULBB __smulbb
-#define ACLE_SMULTT __smultt
-#elif defined(__TI_ARM__)
-
-#elif defined(__CSMC__)
-
-#elif defined(__TASKING__)
-
-#elif defined(_MSC_VER)
-
-#else
-#error Unknown compiler
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-
-#if __ARM_FEATURE_MVE
-#include <arm_mve.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief Add necessary typedefs
+ *
+ * @brief Translate architecture feature flags to CMSIS-NN defines
+ *
+ */
+
+// CMSIS-NN uses the same macro names as CMSIS-DSP
+#if (defined(__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+    #ifndef ARM_MATH_DSP
+        #define ARM_MATH_DSP 1
+    #endif
+#endif
+
+#if defined(__ARM_FEATURE_MVE)
+    #ifndef ARM_MATH_MVEI
+        #define ARM_MATH_MVEI 1
+    #endif
+#endif
+
+/**
+ *
+ * @brief Limits macros
+ *
  */
 
 #define NN_Q31_MAX ((int32_t)(0x7FFFFFFFL))
@@ -182,24 +71,8 @@ extern "C" {
 #define NN_Q15_MIN ((int16_t)(0x8000))
 #define NN_Q7_MIN ((int8_t)(0x80))
 
-/**
- * @brief Error status returned by some functions in the library.
- */
-
-typedef enum
-{
-    ARM_CMSIS_NN_SUCCESS = 0,        /**< No error */
-    ARM_CMSIS_NN_ARG_ERROR = -1,     /**< One or more arguments are incorrect */
-    ARM_CMSIS_NN_NO_IMPL_ERROR = -2, /**<  No implementation available */
-} arm_cmsis_nn_status;
-
-#if defined(ARM_MATH_DSP)
-#define ACLE_SMLABB __smlabb
-#define ACLE_SMLATT __smlatt
-#endif
-
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*ifndef _ARM_NN_MATH_TYPES_H_ */
+#endif /*ifndef ARM_NN_MATH_TYPES_H */

--- a/Include/arm_nn_types.h
+++ b/Include/arm_nn_types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2020-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  Public header file to contain the CMSIS-NN structs for the
  *               TensorFlowLite micro compliant functions
  *
- * $Date:        4 November 2022
- * $Revision:    V.2.2.0
+ * $Date:        18 January 2023
+ * $Revision:    V.2.3.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
 #ifndef _ARM_NN_TYPES_H
@@ -39,6 +39,14 @@ typedef enum
     ARM_SIGMOID = 0, /**< Sigmoid activation function */
     ARM_TANH = 1,    /**< Tanh activation function */
 } arm_nn_activation_type;
+
+/** Function return codes */
+typedef enum
+{
+    ARM_CMSIS_NN_SUCCESS = 0,        /**< No error */
+    ARM_CMSIS_NN_ARG_ERROR = -1,     /**< One or more arguments are incorrect */
+    ARM_CMSIS_NN_NO_IMPL_ERROR = -2, /**<  No implementation available */
+} arm_cmsis_nn_status;
 
 /** CMSIS-NN object to contain the width and height of a tile */
 typedef struct

--- a/README.md
+++ b/README.md
@@ -65,23 +65,23 @@ follows Semantic Versioning 2.0.0 format.
 
 ## Building CMSIS-NN as a library
 It is recommended to use toolchain files from [Arm Ethos-U Core Platform](https://review.mlplatform.org/admin/repos/ml/ethos-u/ethos-u-core-platform) project. These are supporting TARGET_CPU, which is a required argument. Note that if not specifying TARGET_CPU, these toolchains will set some default. The format must be TARGET_CPU=cortex-mXX, see examples below.
-Furthermore CMSIS-NN has a dependency to [CMSIS](https://github.com/ARM-software/CMSIS_5) project.
+
 Here is an example:
 
 ```
 cd </path/to/CMSIS_NN>
 mkdir build
 cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m55 -DCMSIS_PATH=</path/to/CMSIS>
+cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m55
 make
 ```
 
 Some more examples:
 
 ```
-cmake .. -DCMAKE_TOOLCHAIN_FILE=~/ethos-u-core-platform/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m55 -DCMSIS_PATH=</path/to/CMSIS>
-cmake .. -DCMAKE_TOOLCHAIN_FILE=~/ethos-u-core-platform/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m7 -DCMSIS_PATH=</path/to/CMSIS>
-cmake .. -DCMAKE_TOOLCHAIN_FILE=~/ethos-u-core-platform/cmake/toolchain/armclang.cmake -DTARGET_CPU=cortex-m3 -DCMSIS_PATH=</path/to/CMSIS>
+cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain/armclang.cmake -DTARGET_CPU=cortex-m55
+cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m7
+cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain/armclang.cmake -DTARGET_CPU=cortex-m3
 ```
 
 ### Compiler Options
@@ -93,6 +93,11 @@ The compiler option *'-fomit-frame-pointer'* is enabled by default at -O and hig
 you may need to specify '-fomit-frame-pointer'.
 
 The compiler option *'-fno-builtin'* does not utilize optimized implementations of e.g. memcpy and memset, which are heavily used by CMSIS-NN. It can significantly downgrade performance. So this should be avoided. The compiler option *'-ffreestanding'* should also be avoided as it enables '-fno-builtin' implicitly.
+
+### Supported Compilers
+* CMSIS-NN is tested on Arm Compiler 6 and on Arm GNU Toolchain.
+* IAR compiler is not tested and there can be compilation and/or performance issues.
+* Compilation for Host is not supported out of the box. It should be possible to use the C implementation and compile for host with minor stubbing effort.
 
 ## Inclusive Language
 This product confirms to Arm’s inclusive language policy and, to the best of our knowledge, does not contain any non-inclusive language. If you find something that concerns you, email terms@arm.com.

--- a/Source/ActivationFunctions/arm_relu_q15.c
+++ b/Source/ActivationFunctions/arm_relu_q15.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_relu_q15.c
  * Description:  Q15 version of ReLU
  *
- * $Date:        26 October 2022
- * $Revision:    V.1.0.4
+ * $Date:        5 January 2023
+ * $Revision:    V.1.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -65,7 +65,7 @@ void arm_relu_q15(int16_t *data, uint16_t size)
         in = arm_nn_read_q15x2_ia((const int16_t **)&input);
 
         /* extract the first bit */
-        buf = __ROR(in & 0x80008000, 15);
+        buf = ROR(in & 0x80008000, 15);
 
         /* if MSB=1, mask will be 0xFF, 0x0 otherwise */
         mask = __QSUB16(0x00000000, buf);

--- a/Source/ActivationFunctions/arm_relu_q7.c
+++ b/Source/ActivationFunctions/arm_relu_q7.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_relu_q7.c
  * Description:  Q7 version of ReLU
  *
- * $Date:        26 October 2022
- * $Revision:    V.1.1.5
+ * $Date:        5 January 2023
+ * $Revision:    V.1.2.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -65,7 +65,7 @@ void arm_relu_q7(int8_t *data, uint16_t size)
         in = arm_nn_read_s8x4_ia((const int8_t **)&input);
 
         /* extract the first bit */
-        buf = (int32_t)__ROR((uint32_t)in & 0x80808080, 7);
+        buf = (int32_t)ROR((uint32_t)in & 0x80808080, 7);
 
         /* if MSB=1, mask will be 0xFF, 0x0 otherwise */
         mask = __QSUB8(0x00000000, buf);

--- a/Source/BasicMathFunctions/arm_elementwise_add_s8.c
+++ b/Source/BasicMathFunctions/arm_elementwise_add_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_elementwise_add_s8
  * Description:  Elementwise add
  *
- * $Date:        26 October 2022
- * $Revision:    V.3.0.2
+ * $Date:        5 January 2023
+ * $Revision:    V.3.1.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -109,7 +109,7 @@ arm_cmsis_nn_status arm_elementwise_add_s8(const int8_t *input_1_vect,
     int32_t input_2;
     int32_t sum;
 
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
     int32_t a_1, b_1, a_2, b_2;
 
     int32_t offset_1_packed, offset_2_packed;
@@ -128,11 +128,11 @@ arm_cmsis_nn_status arm_elementwise_add_s8(const int8_t *input_1_vect,
         input_1_vect = read_and_pad_reordered(input_1_vect, &b_1, &a_1);
         input_2_vect = read_and_pad_reordered(input_2_vect, &b_2, &a_2);
 
-        a_1 = __SADD16(a_1, offset_1_packed);
-        b_1 = __SADD16(b_1, offset_1_packed);
+        a_1 = SADD16(a_1, offset_1_packed);
+        b_1 = SADD16(b_1, offset_1_packed);
 
-        a_2 = __SADD16(a_2, offset_2_packed);
-        b_2 = __SADD16(b_2, offset_2_packed);
+        a_2 = SADD16(a_2, offset_2_packed);
+        b_2 = SADD16(b_2, offset_2_packed);
 
         /* Sum 1 */
         input_1 = (b_1 & 0x0FFFF) << left_shift;
@@ -197,9 +197,9 @@ arm_cmsis_nn_status arm_elementwise_add_s8(const int8_t *input_1_vect,
     }
 
     loop_count = block_size & 0x3;
-#else
+    #else
     loop_count = block_size;
-#endif
+    #endif
 
     while (loop_count > 0)
     {

--- a/Source/BasicMathFunctions/arm_elementwise_mul_s16.c
+++ b/Source/BasicMathFunctions/arm_elementwise_mul_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s16
  * Description:  Element wise multiplication
  *
- * $Date:        16 January 2023
- * $Revision:    V.2.3.0
+ * $Date:        20 January 2023
+ * $Revision:    V.2.4.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -102,25 +102,25 @@ arm_cmsis_nn_status arm_elementwise_mul_s16(const int16_t *input_1_vect,
         two_halfword_1 = arm_nn_read_q15x2_ia(&input_1_vect);
         two_halfword_2 = arm_nn_read_q15x2_ia(&input_2_vect);
 
-#if defined(ARM_MATH_DSP)
-        mul_res = ACLE_SMULBB(two_halfword_1, two_halfword_2);
-#else
+    #if defined(ARM_MATH_DSP)
+        mul_res = SMULBB(two_halfword_1, two_halfword_2);
+    #else
         input_1 = (int16_t)(two_halfword_1 & 0xFFFF);
         input_2 = (int16_t)(two_halfword_2 & 0xFFFF);
         mul_res = input_1 * input_2;
-#endif
+    #endif
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift);
         mul_res = MAX(mul_res, out_activation_min);
         mul_res = MIN(mul_res, out_activation_max);
         mul_1 = (int16_t)mul_res;
 
-#if defined(ARM_MATH_DSP)
-        mul_res = ACLE_SMULTT(two_halfword_1, two_halfword_2);
-#else
+    #if defined(ARM_MATH_DSP)
+        mul_res = SMULTT(two_halfword_1, two_halfword_2);
+    #else
         input_1 = (int16_t)(two_halfword_1 >> 16);
         input_2 = (int16_t)(two_halfword_2 >> 16);
         mul_res = input_1 * input_2;
-#endif
+    #endif
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift);
         mul_res = MAX(mul_res, out_activation_min);
         mul_res = MIN(mul_res, out_activation_max);

--- a/Source/BasicMathFunctions/arm_elementwise_mul_s16_s8.c
+++ b/Source/BasicMathFunctions/arm_elementwise_mul_s16_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s16_s8.c
  * Description:  Elementwise multiplication of 16 bit input with 8 bit output
  *
- * $Date:        10 January 2023
- * $Revision:    V.1.1.0
+ * $Date:        20 January 2023
+ * $Revision:    V.1.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -81,19 +81,19 @@ arm_cmsis_nn_status arm_elementwise_mul_s16_s8(const int16_t *input_1_vect,
     }
 
 #else
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
 
     while (loop_count > 1)
     {
         int32_t input_1 = arm_nn_read_q15x2_ia(&input_1_vect);
         int32_t input_2 = arm_nn_read_q15x2_ia(&input_2_vect);
 
-        int32_t mul_res = ACLE_SMULBB(input_1, input_2);
+        int32_t mul_res = SMULBB(input_1, input_2);
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift) + out_offset;
         mul_res = CLAMP(mul_res, NN_Q7_MAX, NN_Q7_MIN);
         int32_t mul = (int16_t)(mul_res & 0xFF);
 
-        mul_res = ACLE_SMULTT(input_1, input_2);
+        mul_res = SMULTT(input_1, input_2);
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift) + out_offset;
         mul_res = CLAMP(mul_res, NN_Q7_MAX, NN_Q7_MIN);
         mul |= (int16_t)mul_res << 8;
@@ -101,7 +101,7 @@ arm_cmsis_nn_status arm_elementwise_mul_s16_s8(const int16_t *input_1_vect,
         arm_nn_write_s8x2_ia(&output, mul);
         loop_count -= 2;
     }
-#endif
+    #endif
     for (int i = 0; i < loop_count; i++)
     {
         /* C = A * B */

--- a/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
+++ b/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_elementwise_mul_s8
  * Description:  Element wise multiplication
  *
- * $Date:        16 January 2023
- * $Revision:    V.2.1.0
+ * $Date:        20 January 2023
+ * $Revision:    V.2.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -97,7 +97,7 @@ arm_cmsis_nn_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
     int32_t input_2;
     int32_t mul_res;
 
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
     int32_t a_1, b_1, a_2, b_2;
 
     int32_t offset_1_packed, offset_2_packed;
@@ -116,14 +116,14 @@ arm_cmsis_nn_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
         input_1_vect = read_and_pad_reordered(input_1_vect, &b_1, &a_1);
         input_2_vect = read_and_pad_reordered(input_2_vect, &b_2, &a_2);
 
-        a_1 = __SADD16(a_1, offset_1_packed);
-        b_1 = __SADD16(b_1, offset_1_packed);
+        a_1 = SADD16(a_1, offset_1_packed);
+        b_1 = SADD16(b_1, offset_1_packed);
 
-        a_2 = __SADD16(a_2, offset_2_packed);
-        b_2 = __SADD16(b_2, offset_2_packed);
+        a_2 = SADD16(a_2, offset_2_packed);
+        b_2 = SADD16(b_2, offset_2_packed);
 
         /* Mul 1 */
-        mul_res = ACLE_SMULBB(b_1, b_2);
+        mul_res = SMULBB(b_1, b_2);
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift) + out_offset;
 
         mul_res = MAX(mul_res, out_activation_min);
@@ -131,21 +131,21 @@ arm_cmsis_nn_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
         r1 = (int8_t)mul_res;
 
         /* Mul 3 */
-        mul_res = ACLE_SMULTT(b_1, b_2);
+        mul_res = SMULTT(b_1, b_2);
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift) + out_offset;
         mul_res = MAX(mul_res, out_activation_min);
         mul_res = MIN(mul_res, out_activation_max);
         r3 = (int8_t)mul_res;
 
         /* Mul 2 */
-        mul_res = ACLE_SMULBB(a_1, a_2);
+        mul_res = SMULBB(a_1, a_2);
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift) + out_offset;
         mul_res = MAX(mul_res, out_activation_min);
         mul_res = MIN(mul_res, out_activation_max);
         r2 = (int8_t)mul_res;
 
         /* Mul 4 */
-        mul_res = ACLE_SMULTT(a_1, a_2);
+        mul_res = SMULTT(a_1, a_2);
         mul_res = arm_nn_requantize(mul_res, out_mult, out_shift) + out_offset;
         mul_res = MAX(mul_res, out_activation_min);
         mul_res = MIN(mul_res, out_activation_max);
@@ -157,9 +157,9 @@ arm_cmsis_nn_status arm_elementwise_mul_s8(const int8_t *input_1_vect,
     }
 
     loop_count = block_size & 0x3;
-#else
+    #else
     loop_count = block_size;
-#endif
+    #endif
 
     while (loop_count > 0)
     {

--- a/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        26 October 2022
- * $Revision:    V.3.1.1
+ * $Date:        23 January 2023
+ * $Revision:    V.3.2.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -101,15 +101,15 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
                 for (int i = 0; i < 4; i++)
                 {
                     const int32_t actual_kernel_len = ker_end_idx[i] - ker_begin_idx[i];
-                    arm_nn_mat_mul_core_1x_s8(actual_kernel_len * input_ch,
-                                              (kernel_x - actual_kernel_len) * input_ch,
-                                              input_data + input_begin_idx[i] * input_ch,
-                                              filter_data + (ker_begin_idx[i] * input_ch),
-                                              output_ch,
-                                              conv_params,
-                                              quant_params,
-                                              bias_data,
-                                              output_data);
+                    status = arm_nn_mat_mul_core_1x_s8(actual_kernel_len * input_ch,
+                                                       (kernel_x - actual_kernel_len) * input_ch,
+                                                       input_data + input_begin_idx[i] * input_ch,
+                                                       filter_data + (ker_begin_idx[i] * input_ch),
+                                                       output_ch,
+                                                       conv_params,
+                                                       quant_params,
+                                                       bias_data,
+                                                       output_data);
                     output_data += output_ch;
                 }
             }
@@ -125,7 +125,13 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
                                                         bias_data,
                                                         output_data);
             }
+
+            if (status != ARM_CMSIS_NN_SUCCESS || output_data == NULL)
+            {
+                return ARM_CMSIS_NN_NO_IMPL_ERROR;
+            }
         }
+
         /* Advance to the next batch */
         input_data += (input_x * input_ch);
     }

--- a/Source/ConvolutionFunctions/arm_convolve_1x1_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1x1_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,16 +21,15 @@
  * Title:        arm_convolve_1x1_s8.c
  * Description:  Generic s8 version of 1x1 convolution
  *
- * $Date:        03 November 2022
- * $Revision:    V.1.0.0
+ * $Date:        20 January 2023
+ * $Revision:    V.1.0.1
  *
- * Target Processor:  Arm Cortex-M Processors
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
 #include "arm_nnsupportfunctions.h"
-#include <stdio.h>
 
 /**
  *  @ingroup Public

--- a/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,16 +21,15 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast s8 version of 1x1 convolution (non-square shape)
  *
- * $Date:        03 November 2022
- * $Revision:    V.3.0.3
+ * $Date:        20 January 2023
+ * $Revision:    V.3.0.4
  *
- * Target Processor:  Arm Cortex-M Processors
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
 #include "arm_nnsupportfunctions.h"
-#include <stdio.h>
 
 /**
  *  @ingroup Public

--- a/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_convolve_fast_s16.c
  * Description:  Optimized s16 version of convolution.
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.0.1
+ * $Date:        5 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -168,9 +168,9 @@ arm_cmsis_nn_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
                     ker_a = read_and_pad(ker_a, &ker_a1, &ker_a2);
 
                     ip_b1 = arm_nn_read_q15x2_ia(&ip_as_col);
-                    sum = __SMLAD(ker_a1, ip_b1, sum);
+                    sum = SMLAD(ker_a1, ip_b1, sum);
                     ip_b2 = arm_nn_read_q15x2_ia(&ip_as_col);
-                    sum = __SMLAD(ker_a2, ip_b2, sum);
+                    sum = SMLAD(ker_a2, ip_b2, sum);
 
                     col_count--;
                 }

--- a/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_convolve_s8.c
  * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        26 October 2022
- * $Revision:    V.3.0.1
+ * $Date:        5 January 2023
+ * $Revision:    V.3.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -170,6 +170,10 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
                     padded = 0;
                 }
             }
+            if (out == NULL)
+            {
+                return ARM_CMSIS_NN_NO_IMPL_ERROR;
+            }
         }
         /* Handle left over columns */
         if (buffer_fill_cnt != 0)
@@ -269,7 +273,7 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
                 const int16_t *ip_as_col = buffer_a;
 
                 /* 4 multiply and accumulates are done in one loop. */
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
                 uint16_t col_count = (input_ch * kernel_y * kernel_x) >> 2;
 
                 while (col_count)
@@ -280,17 +284,17 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
                     ker_a = read_and_pad(ker_a, &ker_a1, &ker_a2);
 
                     ip_b1 = arm_nn_read_q15x2_ia(&ip_as_col);
-                    sum = __SMLAD(ker_a1, ip_b1, sum);
+                    sum = SMLAD(ker_a1, ip_b1, sum);
                     ip_b2 = arm_nn_read_q15x2_ia(&ip_as_col);
-                    sum = __SMLAD(ker_a2, ip_b2, sum);
+                    sum = SMLAD(ker_a2, ip_b2, sum);
 
                     col_count--;
                 }
                 /* Handle left over mac */
                 col_count = input_ch * kernel_y * kernel_x & 0x3;
-#else
+    #else
                 uint16_t col_count = input_ch * kernel_y * kernel_x;
-#endif
+    #endif
                 while (col_count)
                 {
                     int8_t ker_a1 = *ker_a++;

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  Optimized s8 depthwise convolution function for channel
  *               multiplier of 1 and 3x3 kernel size.
  *
- * $Date:        27 October 2022
- * $Revision:    V.3.1.2
+ * $Date:        5 January 2023
+ * $Revision:    V.3.2.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -117,7 +117,7 @@ arm_cmsis_nn_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
                 const int8_t *input_ptr = input + (in_h + ker_h_start) * (input_ch * input_x) + in_w * input_ch + in_ch;
                 const int8_t *kernel_ptr = kernel + ker_h_start * (input_ch * 3) + in_ch;
 #if defined(ARM_MATH_DSP)
-                const uint32_t lhs_offset_s16x2 = __PKHBT(input_offset, input_offset, 16);
+                const uint32_t lhs_offset_s16x2 = PKHBT(input_offset, input_offset, 16);
 
                 for (int32_t ker_h = ker_h_start; ker_h < MIN(3, input_y - in_h); ++ker_h)
                 {
@@ -131,42 +131,42 @@ arm_cmsis_nn_status arm_depthwise_conv_3x3_s8(const cmsis_nn_context *ctx,
                         in_val = arm_nn_read_s8x4(input_ptr);
                         ker_val = arm_nn_read_s8x4(kernel_ptr);
 
-                        in_val_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)in_val, 8);
-                        ker_val_1 = __SXTB16_RORn((uint32_t)ker_val, 8);
+                        in_val_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)in_val, 8);
+                        ker_val_1 = SXTB16_RORn((uint32_t)ker_val, 8);
 
-                        out_buff1 = ACLE_SMLABB(in_val_1, ker_val_1, out_buff1);
-                        in_val = __SXTAB16(lhs_offset_s16x2, (uint32_t)in_val);
-                        out_buff3 = ACLE_SMLATT(in_val_1, ker_val_1, out_buff3);
-                        ker_val = __SXTB16((uint32_t)ker_val);
-                        out_buff0 = ACLE_SMLABB(in_val, ker_val, out_buff0);
-                        out_buff2 = ACLE_SMLATT(in_val, ker_val, out_buff2);
+                        out_buff1 = SMLABB(in_val_1, ker_val_1, out_buff1);
+                        in_val = SXTAB16(lhs_offset_s16x2, (uint32_t)in_val);
+                        out_buff3 = SMLATT(in_val_1, ker_val_1, out_buff3);
+                        ker_val = SXTB16((uint32_t)ker_val);
+                        out_buff0 = SMLABB(in_val, ker_val, out_buff0);
+                        out_buff2 = SMLATT(in_val, ker_val, out_buff2);
                     }
 
                     in_val = arm_nn_read_s8x4(input_ptr + input_ch);
                     ker_val = arm_nn_read_s8x4(kernel_ptr + input_ch);
-                    in_val_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)in_val, 8);
-                    ker_val_1 = __SXTB16_RORn((uint32_t)ker_val, 8);
+                    in_val_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)in_val, 8);
+                    ker_val_1 = SXTB16_RORn((uint32_t)ker_val, 8);
 
-                    out_buff1 = ACLE_SMLABB(in_val_1, ker_val_1, out_buff1);
-                    in_val = __SXTAB16(lhs_offset_s16x2, (uint32_t)in_val);
-                    out_buff3 = ACLE_SMLATT(in_val_1, ker_val_1, out_buff3);
-                    ker_val = __SXTB16((uint32_t)ker_val);
-                    out_buff0 = ACLE_SMLABB(in_val, ker_val, out_buff0);
-                    out_buff2 = ACLE_SMLATT(in_val, ker_val, out_buff2);
+                    out_buff1 = SMLABB(in_val_1, ker_val_1, out_buff1);
+                    in_val = SXTAB16(lhs_offset_s16x2, (uint32_t)in_val);
+                    out_buff3 = SMLATT(in_val_1, ker_val_1, out_buff3);
+                    ker_val = SXTB16((uint32_t)ker_val);
+                    out_buff0 = SMLABB(in_val, ker_val, out_buff0);
+                    out_buff2 = SMLATT(in_val, ker_val, out_buff2);
 
                     if ((input_x - in_w) >= 3)
                     {
                         in_val = arm_nn_read_s8x4(input_ptr + (input_ch << 1));
                         ker_val = arm_nn_read_s8x4(kernel_ptr + (input_ch << 1));
-                        in_val_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)in_val, 8);
-                        ker_val_1 = __SXTB16_RORn((uint32_t)ker_val, 8);
+                        in_val_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)in_val, 8);
+                        ker_val_1 = SXTB16_RORn((uint32_t)ker_val, 8);
 
-                        out_buff1 = ACLE_SMLABB(in_val_1, ker_val_1, out_buff1);
-                        in_val = __SXTAB16(lhs_offset_s16x2, (uint32_t)in_val);
-                        out_buff3 = ACLE_SMLATT(in_val_1, ker_val_1, out_buff3);
-                        ker_val = __SXTB16((uint32_t)ker_val);
-                        out_buff0 = ACLE_SMLABB(in_val, ker_val, out_buff0);
-                        out_buff2 = ACLE_SMLATT(in_val, ker_val, out_buff2);
+                        out_buff1 = SMLABB(in_val_1, ker_val_1, out_buff1);
+                        in_val = SXTAB16(lhs_offset_s16x2, (uint32_t)in_val);
+                        out_buff3 = SMLATT(in_val_1, ker_val_1, out_buff3);
+                        ker_val = SXTB16((uint32_t)ker_val);
+                        out_buff0 = SMLABB(in_val, ker_val, out_buff0);
+                        out_buff2 = SMLATT(in_val, ker_val, out_buff2);
                     }
 
                     input_ptr += (input_ch * input_x);

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_fast_s16.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  Optimized s16 depthwise separable convolution function for
  *               channel multiplier of 1.
  *
- * $Date:        26 October 2022
- * $Revision:    V.1.1.1
+ * $Date:        5 January 2023
+ * $Revision:    V.1.2.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -98,7 +98,7 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
     const int32_t output_activation_max = dw_conv_params->activation.max;
     int16_t *buffer_a = (int16_t *)ctx->buf;
 
-#if defined(ARM_MATH_MVEI)
+    #if defined(ARM_MATH_MVEI)
     int16_t *lhs_buffer = buffer_a;
     int16_t *out = output;
     int buffer_count = 0;
@@ -214,7 +214,7 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
         }
     }
 
-#else // ARM_MATH_DSP
+    #else // ARM_MATH_DSP
 
     /* Run the following code in cores using DSP extension */
     int16_t *const col_buffer_start = buffer_a;
@@ -312,30 +312,30 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
                         col_a = arm_nn_read_s16x2(col_pos);
                         col_b = arm_nn_read_s16x2(col_pos + input_ch);
 
-                        row_a2 = __SXTB16(row_b1);
-                        row_b1 = __SXTB16(__ROR(row_b1, 8));
+                        row_a2 = SXTB16(row_b1);
+                        row_b1 = SXTB16(ROR(row_b1, 8));
 
-                        row_b2 = __SXTB16(row_a1);
-                        row_a1 = __SXTB16(__ROR(row_a1, 8));
+                        row_b2 = SXTB16(row_a1);
+                        row_a1 = SXTB16(ROR(row_a1, 8));
 
-                        col_c = __PKHBT(col_b, col_a, 16);
-                        col_a = __PKHTB(col_b, col_a, 16);
-                        row_c = __PKHBT(row_b2, row_a2, 16);
-                        sum_1 = __SMLAD(col_c, row_c, sum_1);
+                        col_c = PKHBT(col_b, col_a, 16);
+                        col_a = PKHTB(col_b, col_a, 16);
+                        row_c = PKHBT(row_b2, row_a2, 16);
+                        sum_1 = SMLAD(col_c, row_c, sum_1);
 
-                        row_c = __PKHBT(row_b1, row_a1, 16);
-                        sum_2 = __SMLAD(col_a, row_c, sum_2);
+                        row_c = PKHBT(row_b1, row_a1, 16);
+                        sum_2 = SMLAD(col_a, row_c, sum_2);
 
                         col_a = arm_nn_read_s16x2(col_pos + 2);
                         col_b = arm_nn_read_s16x2(col_pos + input_ch + 2);
 
-                        col_c = __PKHBT(col_b, col_a, 16);
-                        col_a = __PKHTB(col_b, col_a, 16);
-                        row_c = __PKHTB(row_a2, row_b2, 16);
-                        sum_3 = __SMLAD(col_c, row_c, sum_3);
+                        col_c = PKHBT(col_b, col_a, 16);
+                        col_a = PKHTB(col_b, col_a, 16);
+                        row_c = PKHTB(row_a2, row_b2, 16);
+                        sum_3 = SMLAD(col_c, row_c, sum_3);
 
-                        row_c = __PKHTB(row_a1, row_b1, 16);
-                        sum_4 = __SMLAD(col_a, row_c, sum_4);
+                        row_c = PKHTB(row_a1, row_b1, 16);
+                        sum_4 = SMLAD(col_a, row_c, sum_4);
 
                         row_pos += input_ch << 1;
                         col_pos += input_ch << 1;
@@ -426,7 +426,7 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
         /* Advance to the next batch */
         input += (input_x * input_y * input_ch);
     }
-#endif
+    #endif
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
     return arm_depthwise_conv_s16(ctx,
@@ -449,12 +449,12 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
 int32_t arm_depthwise_conv_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
 {
 #if defined(ARM_MATH_DSP)
-#if defined(ARM_MATH_MVEI)
+    #if defined(ARM_MATH_MVEI)
     /* The + 8 accounts for a worst case out of bounds read of the lhs buffers in the *_nt_t_* function.  */
     return 4 * input_dims->c * filter_dims->w * filter_dims->h * sizeof(int16_t) + 8;
-#else // ARM_MATH_DSP
+    #else // ARM_MATH_DSP
     return input_dims->c * filter_dims->w * filter_dims->h * sizeof(int16_t);
-#endif
+    #endif
 #else
     (void)input_dims;
     (void)filter_dims;

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  Optimized s8 depthwise separable convolution function for
  *               channel multiplier of 1.
  *
- * $Date:        26 October 2022
- * $Revision:    V.3.1.1
+ * $Date:        5 January 2023
+ * $Revision:    V.3.2.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -94,7 +94,7 @@ arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
     const int32_t output_activation_max = dw_conv_params->activation.max;
     int16_t *buffer_a = (int16_t *)ctx->buf;
 
-#ifdef ARM_MATH_MVEI
+    #ifdef ARM_MATH_MVEI
     /* Generate two columns from the input tensor */
     int8_t *lhs_buffer = (int8_t *)buffer_a;
     int8_t *out = output;
@@ -228,7 +228,7 @@ arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
         remaining_ch -= CH_IN_BLOCK_MVE;
     }
 
-#else // ARM_MATH_DSP
+    #else // ARM_MATH_DSP
     /* Run the following code in cores using DSP extension */
     int16_t *const col_buffer_start = buffer_a;
     int16_t *col_buffer = col_buffer_start;
@@ -323,30 +323,30 @@ arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
                     op_a = arm_nn_read_s16x2(col_pos);
                     op_b = arm_nn_read_s16x2(col_pos + input_ch);
 
-                    ip_a2 = __SXTB16(ip_b1);
-                    ip_b1 = __SXTB16(__ROR(ip_b1, 8));
+                    ip_a2 = SXTB16(ip_b1);
+                    ip_b1 = SXTB16(ROR(ip_b1, 8));
 
-                    ip_b2 = __SXTB16(ip_a1);
-                    ip_a1 = __SXTB16(__ROR(ip_a1, 8));
+                    ip_b2 = SXTB16(ip_a1);
+                    ip_a1 = SXTB16(ROR(ip_a1, 8));
 
-                    op_c = __PKHBT(op_b, op_a, 16);
-                    op_a = __PKHTB(op_b, op_a, 16);
-                    op_b = __PKHBT(ip_b2, ip_a2, 16);
-                    sum = __SMLAD(op_c, op_b, sum);
+                    op_c = PKHBT(op_b, op_a, 16);
+                    op_a = PKHTB(op_b, op_a, 16);
+                    op_b = PKHBT(ip_b2, ip_a2, 16);
+                    sum = SMLAD(op_c, op_b, sum);
 
-                    op_b = __PKHBT(ip_b1, ip_a1, 16);
-                    sum_2 = __SMLAD(op_a, op_b, sum_2);
+                    op_b = PKHBT(ip_b1, ip_a1, 16);
+                    sum_2 = SMLAD(op_a, op_b, sum_2);
 
                     op_a = arm_nn_read_s16x2(col_pos + 2);
                     op_b = arm_nn_read_s16x2(col_pos + input_ch + 2);
 
-                    op_c = __PKHBT(op_b, op_a, 16);
-                    op_a = __PKHTB(op_b, op_a, 16);
-                    op_b = __PKHTB(ip_a2, ip_b2, 16);
-                    sum_3 = __SMLAD(op_c, op_b, sum_3);
+                    op_c = PKHBT(op_b, op_a, 16);
+                    op_a = PKHTB(op_b, op_a, 16);
+                    op_b = PKHTB(ip_a2, ip_b2, 16);
+                    sum_3 = SMLAD(op_c, op_b, sum_3);
 
-                    op_b = __PKHTB(ip_a1, ip_b1, 16);
-                    sum_4 = __SMLAD(op_a, op_b, sum_4);
+                    op_b = PKHTB(ip_a1, ip_b1, 16);
+                    sum_4 = SMLAD(op_a, op_b, sum_4);
 
                     row_pos += input_ch << 1;
                     col_pos += input_ch << 1;
@@ -422,7 +422,7 @@ arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
             col_buffer = col_buffer_start;
         }
     }
-#endif
+    #endif
 #else
     /* Run the following code as reference implementation for Cortex-M0 and Cortex-M3 */
     return arm_depthwise_conv_s8(ctx,

--- a/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
+++ b/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_mat_mult_kernel_s8_s16.c
  * Description:  Matrix-multiplication function for convolution
  *
- * $Date:        26 October 2022
- * $Revision:    V.1.1.1
+ * $Date:        5 Januray 2023
+ * $Revision:    V.1.2.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
@@ -79,7 +79,7 @@ int8_t *arm_nn_mat_mult_kernel_s8_s16(const int8_t *input_a,
             ch_1_out_1 = *bias++;
         }
 
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
         uint16_t col_count = num_col_a / 4;
         /* accumulate over the vector */
         while (col_count)
@@ -91,25 +91,25 @@ int8_t *arm_nn_mat_mult_kernel_s8_s16(const int8_t *input_a,
             ip_a0 = read_and_pad(ip_a0, &a01, &a02);
             ip_a1 = read_and_pad(ip_a1, &a11, &a12);
 
-            ch_0_out_0 = __SMLAD(a01, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a01, b1, ch_0_out_1);
-            ch_1_out_0 = __SMLAD(a11, b0, ch_1_out_0);
-            ch_1_out_1 = __SMLAD(a11, b1, ch_1_out_1);
+            ch_0_out_0 = SMLAD(a01, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a01, b1, ch_0_out_1);
+            ch_1_out_0 = SMLAD(a11, b0, ch_1_out_0);
+            ch_1_out_1 = SMLAD(a11, b1, ch_1_out_1);
 
             b0 = arm_nn_read_q15x2_ia(&ip_b0);
             b1 = arm_nn_read_q15x2_ia(&ip_b1);
 
-            ch_0_out_0 = __SMLAD(a02, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a02, b1, ch_0_out_1);
-            ch_1_out_0 = __SMLAD(a12, b0, ch_1_out_0);
-            ch_1_out_1 = __SMLAD(a12, b1, ch_1_out_1);
+            ch_0_out_0 = SMLAD(a02, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a02, b1, ch_0_out_1);
+            ch_1_out_0 = SMLAD(a12, b0, ch_1_out_0);
+            ch_1_out_1 = SMLAD(a12, b1, ch_1_out_1);
 
             col_count--;
         } /* while over col_count */
         col_count = num_col_a & 0x3;
-#else
+    #else
         uint16_t col_count = num_col_a;
-#endif
+    #endif
         while (col_count)
         {
             int8_t a0 = *ip_a0++;
@@ -174,7 +174,7 @@ int8_t *arm_nn_mat_mult_kernel_s8_s16(const int8_t *input_a,
             ch_0_out_1 = *bias++;
         }
 
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
         uint16_t col_count = num_col_a >> 2;
         while (col_count)
         {
@@ -184,20 +184,20 @@ int8_t *arm_nn_mat_mult_kernel_s8_s16(const int8_t *input_a,
 
             ip_a0 = read_and_pad(ip_a0, &a01, &a02);
 
-            ch_0_out_0 = __SMLAD(a01, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a01, b1, ch_0_out_1);
+            ch_0_out_0 = SMLAD(a01, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a01, b1, ch_0_out_1);
 
             b0 = arm_nn_read_q15x2_ia(&ip_b0);
             b1 = arm_nn_read_q15x2_ia(&ip_b1);
-            ch_0_out_0 = __SMLAD(a02, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a02, b1, ch_0_out_1);
+            ch_0_out_0 = SMLAD(a02, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a02, b1, ch_0_out_1);
 
             col_count--;
         }
         col_count = num_col_a & 0x3;
-#else
+    #else
         uint16_t col_count = num_col_a;
-#endif
+    #endif
         while (col_count)
         {
             int8_t a0 = *ip_a0++;

--- a/Source/NNSupportFunctions/arm_nn_lstm_update_cell_state_s16.c
+++ b/Source/NNSupportFunctions/arm_nn_lstm_update_cell_state_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office.com>
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_lstm_update_cell_state_s16.c
  * Description:  Update cell state for an incremental step of LSTM function.
  *
- * $Date:        28 December 2022
- * $Revision:    V.1.1.0
+ * $Date:        20 January 2023
+ * $Revision:    V.1.2.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -77,22 +77,22 @@ void arm_nn_lstm_update_cell_state_s16(const int32_t n_block,
         cell_state += 4;
     }
 #else
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
     while (loop_count > 1)
     {
         int32_t cell_state_01 = arm_nn_read_s16x2(cell_state);
         int32_t forget_gate_01 = arm_nn_read_q15x2_ia(&forget_gate);
 
-        int32_t value_00 = ACLE_SMULBB(cell_state_01, forget_gate_01);
-        int32_t value_01 = ACLE_SMULTT(cell_state_01, forget_gate_01);
+        int32_t value_00 = SMULBB(cell_state_01, forget_gate_01);
+        int32_t value_01 = SMULTT(cell_state_01, forget_gate_01);
         value_00 = arm_nn_divide_by_power_of_two(value_00, 15);
         value_01 = arm_nn_divide_by_power_of_two(value_01, 15);
 
         int32_t input_gate_01 = arm_nn_read_q15x2_ia(&input_gate);
         int32_t cell_gate_01 = arm_nn_read_q15x2_ia(&cell_gate);
 
-        int32_t value_10 = ACLE_SMULBB(input_gate_01, cell_gate_01);
-        int32_t value_11 = ACLE_SMULTT(input_gate_01, cell_gate_01);
+        int32_t value_10 = SMULBB(input_gate_01, cell_gate_01);
+        int32_t value_11 = SMULTT(input_gate_01, cell_gate_01);
 
         value_10 = arm_nn_divide_by_power_of_two(value_10, cell_scale);
         value_11 = arm_nn_divide_by_power_of_two(value_11, cell_scale);
@@ -106,7 +106,7 @@ void arm_nn_lstm_update_cell_state_s16(const int32_t n_block,
         arm_nn_write_q15x2_ia(&cell_state, PACK_Q15x2_32x1(value_00, value_01));
         loop_count -= 2;
     }
-#endif
+    #endif
     for (int i = 0; i < loop_count; i++)
     {
         int32_t value = cell_state[i] * forget_gate[i];

--- a/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_mat_mul_core_1x_s8.c
  * Description:  General Matrix-multiplication function
  *
- * $Date:        13 December 2022
- * $Revision:    V.3.1.2
+ * $Date:        20 January 2023
+ * $Revision:    V.3.1.3
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
 #include "arm_nnsupportfunctions.h"
@@ -70,14 +70,14 @@ arm_cmsis_nn_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
 
         int32_t sum_tmp = 0;
 
-#if defined(ARM_MATH_AUTOVECTORIZE)
+    #if defined(ARM_MATH_AUTOVECTORIZE)
         for (int j = 0; j < row_elements; j++)
         {
             int32_t col = col_base[j];
             sum_tmp += col;
             acc_n0 += row_base[j] * col;
         }
-#else
+    #else
         __ASM volatile(" .p2align 2                             \n"
                        "  vldrb.8         q0, [%[col]], #16     \n"
                        "  wlstp.8         lr, %[cnt], 1f       \n"
@@ -91,7 +91,7 @@ arm_cmsis_nn_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
                        : [col] "+r"(col_base), [sum] "+Te"(sum_tmp), [row0] "+r"(row_base), [out0] "+Te"(acc_n0)
                        : [cnt] "r"(row_elements)
                        : "q0", "q1", "memory", "r14");
-#endif
+    #endif
 
         sum_tmp *= conv_params->input_offset;
         acc_n0 += sum_tmp;
@@ -132,6 +132,7 @@ arm_cmsis_nn_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
         acc_n0 = MIN(acc_n0, conv_params->activation.max);
         *output++ = (int8_t)acc_n0;
     }
+    return ARM_CMSIS_NN_SUCCESS;
 
 #else
     (void)row_elements;
@@ -143,8 +144,8 @@ arm_cmsis_nn_status arm_nn_mat_mul_core_1x_s8(int32_t row_elements,
     (void)quant_params;
     (void)bias;
     (void)output;
+    return ARM_CMSIS_NN_NO_IMPL_ERROR;
 #endif
-    return ARM_CMSIS_NN_SUCCESS;
 }
 
 /**

--- a/Source/NNSupportFunctions/arm_nn_mat_mul_kernel_s16.c
+++ b/Source/NNSupportFunctions/arm_nn_mat_mul_kernel_s16.c
@@ -1,5 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2020, 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +22,10 @@
  * Title:        arm_nn_mat_mult_kernel_s16.c
  * Description:  Matrix-multiplication function for convolution
  *
- * $Date:        26 October 2022
- * $Revision:    V.1.1.1
+ * $Date:        5 Janauray 2023
+ * $Revision:    V.1.2.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
@@ -92,18 +93,18 @@ int16_t *arm_nn_mat_mult_kernel_s16(const int8_t *input_a,
             ip_a0 = read_and_pad(ip_a0, &a01, &a02);
             ip_a1 = read_and_pad(ip_a1, &a11, &a12);
 
-            ch_0_out_0 = __SMLAD(a01, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a01, b1, ch_0_out_1);
-            ch_1_out_0 = __SMLAD(a11, b0, ch_1_out_0);
-            ch_1_out_1 = __SMLAD(a11, b1, ch_1_out_1);
+            ch_0_out_0 = SMLAD(a01, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a01, b1, ch_0_out_1);
+            ch_1_out_0 = SMLAD(a11, b0, ch_1_out_0);
+            ch_1_out_1 = SMLAD(a11, b1, ch_1_out_1);
 
             b0 = arm_nn_read_q15x2_ia(&ip_b0);
             b1 = arm_nn_read_q15x2_ia(&ip_b1);
 
-            ch_0_out_0 = __SMLAD(a02, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a02, b1, ch_0_out_1);
-            ch_1_out_0 = __SMLAD(a12, b0, ch_1_out_0);
-            ch_1_out_1 = __SMLAD(a12, b1, ch_1_out_1);
+            ch_0_out_0 = SMLAD(a02, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a02, b1, ch_0_out_1);
+            ch_1_out_0 = SMLAD(a12, b0, ch_1_out_0);
+            ch_1_out_1 = SMLAD(a12, b1, ch_1_out_1);
 
             col_count--;
         } /* while over col_count */
@@ -193,13 +194,13 @@ int16_t *arm_nn_mat_mult_kernel_s16(const int8_t *input_a,
 
             ip_a0 = read_and_pad(ip_a0, &a01, &a02);
 
-            ch_0_out_0 = __SMLAD(a01, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a01, b1, ch_0_out_1);
+            ch_0_out_0 = SMLAD(a01, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a01, b1, ch_0_out_1);
 
             b0 = arm_nn_read_q15x2_ia(&ip_b0);
             b1 = arm_nn_read_q15x2_ia(&ip_b1);
-            ch_0_out_0 = __SMLAD(a02, b0, ch_0_out_0);
-            ch_0_out_1 = __SMLAD(a02, b1, ch_0_out_1);
+            ch_0_out_0 = SMLAD(a02, b0, ch_0_out_0);
+            ch_0_out_1 = SMLAD(a02, b1, ch_0_out_1);
 
             col_count--;
         }

--- a/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2020-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_mat_mult_s8_nt_t_s8
  * Description:  Matrix multiplication support function with the right-hand-side (rhs) matrix transposed
  *
- * $Date:        13 December 2022
- * $Revision:    V.2.0.3
+ * $Date:        5 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Arm Cortex-M Processors
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -88,7 +88,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             const int8_t *col_base = rhs + i * rhs_cols;
             int32_t sum_tmp = 0;
 
-#if defined(ARM_MATH_AUTOVECTORIZE)
+    #if defined(ARM_MATH_AUTOVECTORIZE)
             for (int j = 0; j < rhs_cols; j++)
             {
                 int32_t col = col_base[j];
@@ -98,7 +98,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 acc_n2 += ip_row_2[j] * col;
                 acc_n3 += ip_row_3[j] * col;
             }
-#else
+    #else
             __ASM volatile(" .p2align 2                             \n"
                            "   vldrb.8         q0, [%[col]], #16    \n"
                            "   wlstp.8         lr, %[cnt], 1f       \n"
@@ -127,7 +127,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                              [out3] "+Te"(acc_n3)
                            : [cnt] "r"(rhs_cols)
                            : "q0", "q1", "q2", "q3", "q4", "memory", "r14");
-#endif
+    #endif
             int32x4_t res = {acc_n0, acc_n1, acc_n2, acc_n3};
             sum_tmp *= lhs_offset;
             if (bias)
@@ -162,14 +162,14 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             const int8_t *col_base = rhs + i * rhs_cols;
             int32_t sum_tmp = 0;
 
-#if defined(ARM_MATH_AUTOVECTORIZE)
+    #if defined(ARM_MATH_AUTOVECTORIZE)
             for (int j = 0; j < rhs_cols; j++)
             {
                 int32_t col = col_base[j];
                 sum_tmp += col;
                 acc_n0 += lhs_vec[j] * col;
             }
-#else
+    #else
             __ASM volatile(" .p2align 2                             \n"
                            "   vldrb.8         q0, [%[col]], #16    \n"
                            "   wlstp.8         lr, %[cnt], 1f       \n"
@@ -183,7 +183,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                            : [col] "+r"(col_base), [sum] "+Te"(sum_tmp), [row0] "+r"(lhs_vec), [out0] "+Te"(acc_n0)
                            : [cnt] "r"(rhs_cols)
                            : "q0", "q1", "memory", "r14");
-#endif
+    #endif
             sum_tmp *= lhs_offset;
             sum_tmp += acc_n0;
             if (bias)
@@ -263,132 +263,132 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             for (; rhs_cols_idx <= (rhs_cols - 16); rhs_cols_idx += 16)
             {
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val2 = __SXTB16(val1);
+                val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
+                val3 = SXTB16(val0);
                 val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
-                val1 = __SXTB16_RORn(val1, 8);
-                val0 = __SXTB16_RORn(val0, 8);
+                val1 = SXTB16_RORn(val1, 8);
+                val0 = SXTB16_RORn(val0, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val3, val2, res00);
-                val5 = __SXTB16(val4);
-                res00 = __SMLAD(val0, val1, res00);
-                val4 = __SXTB16_RORn(val4, 8);
-                res01 = __SMLAD(val3, val5, res01);
-                res01 = __SMLAD(val0, val4, res01);
+                res00 = SMLAD(val3, val2, res00);
+                val5 = SXTB16(val4);
+                res00 = SMLAD(val0, val1, res00);
+                val4 = SXTB16_RORn(val4, 8);
+                res01 = SMLAD(val3, val5, res01);
+                res01 = SMLAD(val0, val4, res01);
 
                 // 4 x MAC res10, res11
                 val0 = arm_nn_read_s8x4((const int8_t *)&lhs_ptr[lhs_off0]);
-                val3 = __SXTB16(val0);
-                val0 = __SXTB16_RORn(val0, 8);
-                res10 = __SMLAD(val3, val2, res10);
-                res11 = __SMLAD(val3, val5, res11);
-                res10 = __SMLAD(val0, val1, res10);
+                val3 = SXTB16(val0);
+                val0 = SXTB16_RORn(val0, 8);
+                res10 = SMLAD(val3, val2, res10);
+                res11 = SMLAD(val3, val5, res11);
+                res10 = SMLAD(val0, val1, res10);
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                res11 = __SMLAD(val0, val4, res11);
+                res11 = SMLAD(val0, val4, res11);
 
                 val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
-                val2 = __SXTB16(val1);
+                val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val1 = __SXTB16_RORn(val1, 8);
-                val0 = __SXTB16_RORn(val0, 8);
+                val3 = SXTB16(val0);
+                val1 = SXTB16_RORn(val1, 8);
+                val0 = SXTB16_RORn(val0, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val3, val2, res00);
-                val5 = __SXTB16(val4);
-                res00 = __SMLAD(val0, val1, res00);
-                val4 = __SXTB16_RORn(val4, 8);
-                res01 = __SMLAD(val3, val5, res01);
-                res01 = __SMLAD(val0, val4, res01);
+                res00 = SMLAD(val3, val2, res00);
+                val5 = SXTB16(val4);
+                res00 = SMLAD(val0, val1, res00);
+                val4 = SXTB16_RORn(val4, 8);
+                res01 = SMLAD(val3, val5, res01);
+                res01 = SMLAD(val0, val4, res01);
 
                 // 4 x MAC res10, res11
                 val0 = arm_nn_read_s8x4((const int8_t *)&lhs_ptr[lhs_off0]);
-                val3 = __SXTB16(val0);
-                val0 = __SXTB16_RORn(val0, 8);
-                res10 = __SMLAD(val3, val2, res10);
-                res11 = __SMLAD(val3, val5, res11);
-                res10 = __SMLAD(val0, val1, res10);
+                val3 = SXTB16(val0);
+                val0 = SXTB16_RORn(val0, 8);
+                res10 = SMLAD(val3, val2, res10);
+                res11 = SMLAD(val3, val5, res11);
+                res10 = SMLAD(val0, val1, res10);
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                res11 = __SMLAD(val0, val4, res11);
+                res11 = SMLAD(val0, val4, res11);
 
                 val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
-                val2 = __SXTB16(val1);
+                val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val1 = __SXTB16_RORn(val1, 8);
-                val0 = __SXTB16_RORn(val0, 8);
+                val3 = SXTB16(val0);
+                val1 = SXTB16_RORn(val1, 8);
+                val0 = SXTB16_RORn(val0, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val3, val2, res00);
-                val5 = __SXTB16(val4);
-                res00 = __SMLAD(val0, val1, res00);
-                val4 = __SXTB16_RORn(val4, 8);
-                res01 = __SMLAD(val3, val5, res01);
-                res01 = __SMLAD(val0, val4, res01);
+                res00 = SMLAD(val3, val2, res00);
+                val5 = SXTB16(val4);
+                res00 = SMLAD(val0, val1, res00);
+                val4 = SXTB16_RORn(val4, 8);
+                res01 = SMLAD(val3, val5, res01);
+                res01 = SMLAD(val0, val4, res01);
 
                 // 4 x MAC res10, res11
                 val0 = arm_nn_read_s8x4((const int8_t *)&lhs_ptr[lhs_off0]);
-                val3 = __SXTB16(val0);
-                val0 = __SXTB16_RORn(val0, 8);
-                res10 = __SMLAD(val3, val2, res10);
-                res11 = __SMLAD(val3, val5, res11);
-                res10 = __SMLAD(val0, val1, res10);
+                val3 = SXTB16(val0);
+                val0 = SXTB16_RORn(val0, 8);
+                res10 = SMLAD(val3, val2, res10);
+                res11 = SMLAD(val3, val5, res11);
+                res10 = SMLAD(val0, val1, res10);
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                res11 = __SMLAD(val0, val4, res11);
+                res11 = SMLAD(val0, val4, res11);
 
                 val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
-                val2 = __SXTB16(val1);
+                val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val1 = __SXTB16_RORn(val1, 8);
-                val0 = __SXTB16_RORn(val0, 8);
+                val3 = SXTB16(val0);
+                val1 = SXTB16_RORn(val1, 8);
+                val0 = SXTB16_RORn(val0, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val3, val2, res00);
-                val5 = __SXTB16(val4);
-                res00 = __SMLAD(val0, val1, res00);
-                val4 = __SXTB16_RORn(val4, 8);
-                res01 = __SMLAD(val3, val5, res01);
-                res01 = __SMLAD(val0, val4, res01);
+                res00 = SMLAD(val3, val2, res00);
+                val5 = SXTB16(val4);
+                res00 = SMLAD(val0, val1, res00);
+                val4 = SXTB16_RORn(val4, 8);
+                res01 = SMLAD(val3, val5, res01);
+                res01 = SMLAD(val0, val4, res01);
 
                 // 4 x MAC res10, res11
                 val0 = arm_nn_read_s8x4((const int8_t *)&lhs_ptr[lhs_off0]);
-                val3 = __SXTB16(val0);
-                val0 = __SXTB16_RORn(val0, 8);
-                res10 = __SMLAD(val3, val2, res10);
-                res11 = __SMLAD(val3, val5, res11);
-                res10 = __SMLAD(val0, val1, res10);
-                res11 = __SMLAD(val0, val4, res11);
+                val3 = SXTB16(val0);
+                val0 = SXTB16_RORn(val0, 8);
+                res10 = SMLAD(val3, val2, res10);
+                res11 = SMLAD(val3, val5, res11);
+                res10 = SMLAD(val0, val1, res10);
+                res11 = SMLAD(val0, val4, res11);
             }
 
             for (; rhs_cols_idx <= (rhs_cols - 4); rhs_cols_idx += 4)
             {
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val2 = __SXTB16(val1);
+                val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
+                val3 = SXTB16(val0);
                 val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
-                val1 = __SXTB16_RORn(val1, 8);
-                val0 = __SXTB16_RORn(val0, 8);
+                val1 = SXTB16_RORn(val1, 8);
+                val0 = SXTB16_RORn(val0, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val3, val2, res00);
-                val5 = __SXTB16(val4);
-                res00 = __SMLAD(val0, val1, res00);
-                val4 = __SXTB16_RORn(val4, 8);
-                res01 = __SMLAD(val3, val5, res01);
-                res01 = __SMLAD(val0, val4, res01);
+                res00 = SMLAD(val3, val2, res00);
+                val5 = SXTB16(val4);
+                res00 = SMLAD(val0, val1, res00);
+                val4 = SXTB16_RORn(val4, 8);
+                res01 = SMLAD(val3, val5, res01);
+                res01 = SMLAD(val0, val4, res01);
 
                 // 4 x MAC res10, res11
                 val0 = arm_nn_read_s8x4((const int8_t *)&lhs_ptr[lhs_off0]);
-                val3 = __SXTB16(val0);
-                val0 = __SXTB16_RORn(val0, 8);
-                res10 = __SMLAD(val3, val2, res10);
-                res11 = __SMLAD(val3, val5, res11);
-                res10 = __SMLAD(val0, val1, res10);
-                res11 = __SMLAD(val0, val4, res11);
+                val3 = SXTB16(val0);
+                val0 = SXTB16_RORn(val0, 8);
+                res10 = SMLAD(val3, val2, res10);
+                res11 = SMLAD(val3, val5, res11);
+                res10 = SMLAD(val0, val1, res10);
+                res11 = SMLAD(val0, val4, res11);
             }
 
             for (; rhs_cols_idx < rhs_cols; ++rhs_cols_idx)
@@ -459,66 +459,66 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val5 = __SXTB16(val2);
-                val4 = __SXTB16(val1);
-                val0 = __SXTB16_RORn(val0, 8);
-                val2 = __SXTB16_RORn(val2, 8);
-                val1 = __SXTB16_RORn(val1, 8);
+                val3 = SXTB16(val0);
+                val5 = SXTB16(val2);
+                val4 = SXTB16(val1);
+                val0 = SXTB16_RORn(val0, 8);
+                val2 = SXTB16_RORn(val2, 8);
+                val1 = SXTB16_RORn(val1, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val5, val3, res00);
-                res00 = __SMLAD(val2, val0, res00);
-                res01 = __SMLAD(val5, val4, res01);
-                res01 = __SMLAD(val2, val1, res01);
+                res00 = SMLAD(val5, val3, res00);
+                res00 = SMLAD(val2, val0, res00);
+                res01 = SMLAD(val5, val4, res01);
+                res01 = SMLAD(val2, val1, res01);
 
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val5 = __SXTB16(val2);
-                val4 = __SXTB16(val1);
-                val0 = __SXTB16_RORn(val0, 8);
-                val2 = __SXTB16_RORn(val2, 8);
-                val1 = __SXTB16_RORn(val1, 8);
+                val3 = SXTB16(val0);
+                val5 = SXTB16(val2);
+                val4 = SXTB16(val1);
+                val0 = SXTB16_RORn(val0, 8);
+                val2 = SXTB16_RORn(val2, 8);
+                val1 = SXTB16_RORn(val1, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val5, val3, res00);
-                res00 = __SMLAD(val2, val0, res00);
-                res01 = __SMLAD(val5, val4, res01);
-                res01 = __SMLAD(val2, val1, res01);
+                res00 = SMLAD(val5, val3, res00);
+                res00 = SMLAD(val2, val0, res00);
+                res01 = SMLAD(val5, val4, res01);
+                res01 = SMLAD(val2, val1, res01);
 
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val5 = __SXTB16(val2);
-                val4 = __SXTB16(val1);
-                val0 = __SXTB16_RORn(val0, 8);
-                val2 = __SXTB16_RORn(val2, 8);
-                val1 = __SXTB16_RORn(val1, 8);
+                val3 = SXTB16(val0);
+                val5 = SXTB16(val2);
+                val4 = SXTB16(val1);
+                val0 = SXTB16_RORn(val0, 8);
+                val2 = SXTB16_RORn(val2, 8);
+                val1 = SXTB16_RORn(val1, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val5, val3, res00);
-                res00 = __SMLAD(val2, val0, res00);
-                res01 = __SMLAD(val5, val4, res01);
-                res01 = __SMLAD(val2, val1, res01);
+                res00 = SMLAD(val5, val3, res00);
+                res00 = SMLAD(val2, val0, res00);
+                res01 = SMLAD(val5, val4, res01);
+                res01 = SMLAD(val2, val1, res01);
 
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val5 = __SXTB16(val2);
-                val4 = __SXTB16(val1);
-                val0 = __SXTB16_RORn(val0, 8);
-                val2 = __SXTB16_RORn(val2, 8);
-                val1 = __SXTB16_RORn(val1, 8);
+                val3 = SXTB16(val0);
+                val5 = SXTB16(val2);
+                val4 = SXTB16(val1);
+                val0 = SXTB16_RORn(val0, 8);
+                val2 = SXTB16_RORn(val2, 8);
+                val1 = SXTB16_RORn(val1, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val5, val3, res00);
-                res00 = __SMLAD(val2, val0, res00);
-                res01 = __SMLAD(val5, val4, res01);
-                res01 = __SMLAD(val2, val1, res01);
+                res00 = SMLAD(val5, val3, res00);
+                res00 = SMLAD(val2, val0, res00);
+                res01 = SMLAD(val5, val4, res01);
+                res01 = SMLAD(val2, val1, res01);
             }
 
             for (; rhs_cols_idx <= (rhs_cols - 4); rhs_cols_idx += 4)
@@ -526,18 +526,18 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
-                val3 = __SXTB16(val0);
-                val5 = __SXTB16(val2);
-                val4 = __SXTB16(val1);
-                val0 = __SXTB16_RORn(val0, 8);
-                val2 = __SXTB16_RORn(val2, 8);
-                val1 = __SXTB16_RORn(val1, 8);
+                val3 = SXTB16(val0);
+                val5 = SXTB16(val2);
+                val4 = SXTB16(val1);
+                val0 = SXTB16_RORn(val0, 8);
+                val2 = SXTB16_RORn(val2, 8);
+                val1 = SXTB16_RORn(val1, 8);
 
                 // 4 x MAC res00, res01
-                res00 = __SMLAD(val5, val3, res00);
-                res00 = __SMLAD(val2, val0, res00);
-                res01 = __SMLAD(val5, val4, res01);
-                res01 = __SMLAD(val2, val1, res01);
+                res00 = SMLAD(val5, val3, res00);
+                res00 = SMLAD(val2, val0, res00);
+                res01 = SMLAD(val5, val4, res01);
+                res01 = SMLAD(val2, val1, res01);
             }
 
             // Left-over accumulations

--- a/Source/NNSupportFunctions/arm_nn_vec_mat_mul_result_acc_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_vec_mat_mul_result_acc_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_vec_mat_mul_result_acc_s8.c
  * Description:  Multiplies a matrix by a vector and accumulate with output.
  *
- * $Date:        10 January 2023
- * $Revision:    V.1.1.0
+ * $Date:        20 January 2023
+ * $Revision:    V.1.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -171,23 +171,23 @@ void arm_nn_vec_mat_mul_result_acc_s8(const int8_t *lhs_in,
             for (int j = col_loop_cnt; j != 0; j--)
             {
                 int32_t vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-                int32_t vec_1 = __SXTB16_RORn((uint32_t)vec_0, 8);
+                int32_t vec_1 = SXTB16_RORn((uint32_t)vec_0, 8);
 
-                vec_0 = __SXTB16(vec_0);
+                vec_0 = SXTB16(vec_0);
 
                 int32_t ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-                int32_t ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-                acc_0 = __SMLAD(ker_1, vec_1, acc_0);
+                int32_t ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+                acc_0 = SMLAD(ker_1, vec_1, acc_0);
 
-                ker_0 = __SXTB16(ker_0);
-                acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+                ker_0 = SXTB16(ker_0);
+                acc_0 = SMLAD(ker_0, vec_0, acc_0);
 
                 ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-                ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-                acc_1 = __SMLAD(ker_1, vec_1, acc_1);
+                ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+                acc_1 = SMLAD(ker_1, vec_1, acc_1);
 
-                ker_0 = __SXTB16(ker_0);
-                acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+                ker_0 = SXTB16(ker_0);
+                acc_1 = SMLAD(ker_0, vec_0, acc_1);
             }
 
             for (int k = col_loop_cnt * 4; k < rhs_cols; k++)
@@ -226,15 +226,15 @@ void arm_nn_vec_mat_mul_result_acc_s8(const int8_t *lhs_in,
             for (int i = col_loop_cnt; i != 0; i--)
             {
                 int32_t vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-                int32_t vec_1 = __SXTB16_RORn((uint32_t)vec_0, 8);
-                vec_0 = __SXTB16(vec_0);
+                int32_t vec_1 = SXTB16_RORn((uint32_t)vec_0, 8);
+                vec_0 = SXTB16(vec_0);
 
                 int32_t ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-                int32_t ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-                ker_0 = __SXTB16(ker_0);
+                int32_t ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+                ker_0 = SXTB16(ker_0);
 
-                acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-                acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+                acc_0 = SMLAD(ker_1, vec_1, acc_0);
+                acc_0 = SMLAD(ker_0, vec_0, acc_0);
             }
 
             for (int j = col_loop_cnt * 4; j < rhs_cols; j++)

--- a/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s16.c
+++ b/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2020-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,14 +21,15 @@
  * Title:        arm_nn_vec_mat_mult_t_s16
  * Description:  s16 vector by matrix (transposed) multiplication
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.1.1
+ * $Date:        5 January 2023
+ * $Revision:    V.2.2.0
  *
- * Target Processor:  Cortex-M
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
 #include "arm_nnsupportfunctions.h"
+
 #define MAX_COL_COUNT (512)
 
 /**
@@ -66,7 +67,7 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const int16_t *lhs,
         rhs_cols_fast = MAX_COL_COUNT;
     }
 
-#if defined(ARM_MATH_MVEI)
+    #if defined(ARM_MATH_MVEI)
     int32_t row_loop_cnt = rhs_rows / 4;
     int32_t col_loop_cnt = (rhs_cols_fast + 7) / 8;
 
@@ -214,7 +215,7 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const int16_t *lhs,
         rhs += rhs_cols;
     }
 
-#else // ARM_MATH_MVEI
+    #else // ARM_MATH_MVEI
 
     const int32_t row_loop_cnt = rhs_rows / 2;
 
@@ -242,13 +243,13 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const int16_t *lhs,
 
             rhs_0 = read_and_pad(rhs_0, &ker_0, &ker_1);
 
-            acc_0 = __SMLAD(ker_0, vec_part_0, acc_0);
-            acc_0 = __SMLAD(ker_1, vec_part_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_part_0, acc_0);
+            acc_0 = SMLAD(ker_1, vec_part_1, acc_0);
 
             rhs_1 = read_and_pad(rhs_1, &ker_0, &ker_1);
 
-            acc_1 = __SMLAD(ker_0, vec_part_0, acc_1);
-            acc_1 = __SMLAD(ker_1, vec_part_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_part_0, acc_1);
+            acc_1 = SMLAD(ker_1, vec_part_1, acc_1);
         }
 
         acc_64_0 += acc_0;
@@ -297,10 +298,10 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const int16_t *lhs,
             rhs_0 = read_and_pad(rhs_0, &ker_0, &ker_1);
 
             vec = arm_nn_read_q15x2_ia(&lhs_vec);
-            acc_0 = __SMLAD(ker_0, vec, acc_0);
+            acc_0 = SMLAD(ker_0, vec, acc_0);
 
             vec = arm_nn_read_q15x2_ia(&lhs_vec);
-            acc_0 = __SMLAD(ker_1, vec, acc_0);
+            acc_0 = SMLAD(ker_1, vec, acc_0);
         }
 
         acc_64_0 += acc_0;
@@ -324,8 +325,8 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const int16_t *lhs,
         *dst++ = (int16_t)tmp;
     }
 
-#endif // ARM_MATH_MVEI
-#else  // ARM_MATH_DSP
+    #endif // ARM_MATH_MVEI
+#else      // ARM_MATH_DSP
     for (int i_row_loop_cnt = 0; i_row_loop_cnt < rhs_rows; i_row_loop_cnt++)
     {
         const int16_t *lhs_ptr = lhs;
@@ -358,7 +359,7 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s16(const int16_t *lhs,
         *dst++ = (int16_t)result;
         rhs += rhs_cols;
     }
-#endif // ARM_MATH_DSP
+#endif     // ARM_MATH_DSP
 
     return ARM_CMSIS_NN_SUCCESS;
 }

--- a/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2020-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_vec_mat_mult_t_s8
  * Description:  s8 vector by matrix (transposed) multiplication
  *
- * $Date:        10 November 2022
- * $Revision:    V.5.1.0
+ * $Date:        5 January 2023
+ * $Revision:    V.5.2.0
  *
- * Target Processor:  Cortex-M
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -186,7 +186,7 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s8(const int8_t *lhs,
 #elif defined(ARM_MATH_DSP)
     const int32_t row_loop_cnt = rhs_rows / 2;
     const int16_t lhs_offset_s16 = (int16_t)lhs_offset;
-    const uint32_t lhs_offset_s16x2 = __PKHBT(lhs_offset_s16, lhs_offset_s16, 16);
+    const uint32_t lhs_offset_s16x2 = PKHBT(lhs_offset_s16, lhs_offset_s16, 16);
 
     for (int32_t i = 0; i < row_loop_cnt; i++)
     {
@@ -208,23 +208,23 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s8(const int8_t *lhs,
         for (int j = col_loop_cnt; j != 0; j--)
         {
             int32_t vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            int32_t vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            int32_t vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
 
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
 
             int32_t ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            int32_t ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
+            int32_t ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
 
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
 
             ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
 
-            acc_1 = __SMLAD(ker_1, vec_1, acc_1);
-            acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+            acc_1 = SMLAD(ker_1, vec_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_0, acc_1);
         }
 
         for (int k = col_loop_cnt * 4; k < rhs_cols; k++)
@@ -268,15 +268,15 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s8(const int8_t *lhs,
         for (int i = col_loop_cnt; i != 0; i--)
         {
             int32_t vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            int32_t vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            int32_t vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
 
             int32_t ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            int32_t ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
+            int32_t ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
 
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
         }
 
         for (int j = col_loop_cnt * 4; j < rhs_cols; j++)

--- a/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_svdf_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_svdf_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2021-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  s8 vector by matrix (transposed) multiplication with
  *               s16 output. Targetted at SVDF operator.
  *
- * $Date:        8 November 2022
- * $Revision:    V.3.0.0
+ * $Date:        5 January 2023
+ * $Revision:    V.3.1.0
  *
- * Target Processor:  Cortex-M
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -150,7 +150,7 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_svdf_s8(const int8_t *lhs,
         rhs += rhs_cols;
 
         const int32_t offsets = rhs_sum_0 * lhs_offset;
-        acc_0 = __QADD(acc_0, offsets);
+        acc_0 = QADD(acc_0, offsets);
         acc_0 = arm_nn_requantize(acc_0, dst_multiplier, dst_shift);
 
         // Clamp the result
@@ -164,7 +164,7 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_svdf_s8(const int8_t *lhs,
 
     const int16_t lhs_offset_s16 = lhs_offset;
 
-    const uint32_t lhs_offset_s16x2 = __PKHBT(lhs_offset_s16, lhs_offset_s16, 16);
+    const uint32_t lhs_offset_s16x2 = PKHBT(lhs_offset_s16, lhs_offset_s16, 16);
     for (int32_t i = 0; i < row_loop_cnt; i++)
     {
         int32_t acc_0 = 0;
@@ -179,100 +179,100 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_svdf_s8(const int8_t *lhs,
 
         int32_t vec_0, vec_1, ker_0, ker_1;
 
-#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-#pragma clang loop unroll(disable)
-#endif
+    #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+        #pragma clang loop unroll(disable)
+    #endif
         for (; rhs_cols_idx <= (rhs_cols - 16); rhs_cols_idx += 16)
         {
             // 4 x MAC acc_0, acc1
             vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_1 = __SMLAD(ker_1, vec_1, acc_1);
-            acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_1 = SMLAD(ker_1, vec_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_0, acc_1);
 
             // 4 x MAC acc_0, acc1
             vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_1 = __SMLAD(ker_1, vec_1, acc_1);
-            acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_1 = SMLAD(ker_1, vec_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_0, acc_1);
 
             // 4 x MAC acc_0, acc1
             vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_1 = __SMLAD(ker_1, vec_1, acc_1);
-            acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_1 = SMLAD(ker_1, vec_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_0, acc_1);
 
             // 4 x MAC acc_0, acc1
             vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
             ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
-            acc_1 = __SMLAD(ker_1, vec_1, acc_1);
-            acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
+            acc_1 = SMLAD(ker_1, vec_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_0, acc_1);
         }
 
-#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-#pragma clang loop unroll(disable)
-#endif
+    #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+        #pragma clang loop unroll(disable)
+    #endif
         for (; rhs_cols_idx <= (rhs_cols - 4); rhs_cols_idx += 4)
         {
             vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            vec_1 = __SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
+            vec_1 = SXTAB16_RORn(lhs_offset_s16x2, (uint32_t)vec_0, 8);
 
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
 
             ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
 
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
 
             ker_0 = arm_nn_read_s8x4_ia(&rhs_1);
-            ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
+            ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
 
-            acc_1 = __SMLAD(ker_1, vec_1, acc_1);
-            acc_1 = __SMLAD(ker_0, vec_0, acc_1);
+            acc_1 = SMLAD(ker_1, vec_1, acc_1);
+            acc_1 = SMLAD(ker_0, vec_0, acc_1);
         }
 
-#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-#pragma clang loop unroll(disable)
-#endif
+    #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+        #pragma clang loop unroll(disable)
+    #endif
         for (; rhs_cols_idx < rhs_cols; ++rhs_cols_idx)
         {
             const int32_t lhs_temp = (*lhs_vec + lhs_offset);
@@ -304,15 +304,15 @@ arm_cmsis_nn_status arm_nn_vec_mat_mult_t_svdf_s8(const int8_t *lhs,
         for (int i = col_loop_cnt; i != 0; i--)
         {
             int32_t vec_0 = arm_nn_read_s8x4_ia(&lhs_vec);
-            int32_t vec_1 = __SXTAB16(lhs_offset_s16x2, __ROR((uint32_t)vec_0, 8));
-            vec_0 = __SXTAB16(lhs_offset_s16x2, vec_0);
+            int32_t vec_1 = SXTAB16(lhs_offset_s16x2, ROR((uint32_t)vec_0, 8));
+            vec_0 = SXTAB16(lhs_offset_s16x2, vec_0);
 
             int32_t ker_0 = arm_nn_read_s8x4_ia(&rhs_0);
-            int32_t ker_1 = __SXTB16_RORn((uint32_t)ker_0, 8);
-            ker_0 = __SXTB16(ker_0);
+            int32_t ker_1 = SXTB16_RORn((uint32_t)ker_0, 8);
+            ker_0 = SXTB16(ker_0);
 
-            acc_0 = __SMLAD(ker_1, vec_1, acc_0);
-            acc_0 = __SMLAD(ker_0, vec_0, acc_0);
+            acc_0 = SMLAD(ker_1, vec_1, acc_0);
+            acc_0 = SMLAD(ker_0, vec_0, acc_0);
         }
         for (int j = col_loop_cnt * 4; j < rhs_cols; j++)
         {

--- a/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
+++ b/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2020, 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_q7_to_q15_with_offset.c
  * Description:  Converts the elements of the Q7 vector to Q15 vector with an added offset
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.0.3
+ * $Date:        5 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -73,18 +73,18 @@ void arm_q7_to_q15_with_offset(const int8_t *src, int16_t *dst, uint32_t block_s
     block_cnt = block_size >> 2;
 
     /* First part of the processing with loop unrolling.  Compute 4 outputs at a time. */
-    const int32_t offset_q15x2 = __PKHBT(offset, offset, 16);
+    const int32_t offset_q15x2 = PKHBT(offset, offset, 16);
     while (block_cnt > 0)
     {
         /* convert from s8 to s16 and then store the results in the destination buffer */
         in_q7x4 = arm_nn_read_s8x4_ia(&src);
 
         /* Extract and sign extend each of the four s8 values to s16 */
-        in_q15x2_1 = __SXTAB16(offset_q15x2, __ROR(in_q7x4, 8));
-        in_q15x2_2 = __SXTAB16(offset_q15x2, in_q7x4);
+        in_q15x2_1 = SXTAB16(offset_q15x2, ROR(in_q7x4, 8));
+        in_q15x2_2 = SXTAB16(offset_q15x2, in_q7x4);
 
-        out_q15x2_2 = __PKHTB(in_q15x2_1, in_q15x2_2, 16);
-        out_q15x2_1 = __PKHBT(in_q15x2_2, in_q15x2_1, 16);
+        out_q15x2_2 = PKHTB(in_q15x2_1, in_q15x2_2, 16);
+        out_q15x2_1 = PKHBT(in_q15x2_2, in_q15x2_1, 16);
 
         arm_nn_write_q15x2_ia(&dst, out_q15x2_1);
         arm_nn_write_q15x2_ia(&dst, out_q15x2_2);

--- a/Source/PoolingFunctions/arm_avgpool_s16.c
+++ b/Source/PoolingFunctions/arm_avgpool_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_avgpool_s16.c
  * Description:  Pooling function implementations
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.2.1
+ * $Date:        5 January 2023
+ * $Revision:    V.2.3.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -222,7 +222,7 @@ arm_cmsis_nn_status arm_avgpool_s16(const cmsis_nn_context *ctx,
                     {
                         for (int i = 0; i < ch_src; i++)
                         {
-                            buffer[i] = __QADD(start[i], buffer[i]);
+                            buffer[i] = QADD(start[i], buffer[i]);
                         }
                     }
                     count++;

--- a/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_avgpool_s8.c
  * Description:  Pooling function implementations
  *
- * $Date:        26 October 2022
- * $Revision:    V.3.0.3
+ * $Date:        5 January 2023
+ * $Revision:    V.3.1.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -245,7 +245,7 @@ arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
     }
     int32_t *buffer = (int32_t *)ctx->buf;
 
-#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_DSP)
 
     /* Run the following code for CPU's with DSP extension
      */
@@ -282,7 +282,7 @@ arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
                     {
                         for (int i = 0; i < ch_src; i++)
                         {
-                            buffer[i] = __QADD(start[i], buffer[i]);
+                            buffer[i] = QADD(start[i], buffer[i]);
                         }
                     }
                     count++;
@@ -299,7 +299,7 @@ arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
             dst += ch_src;
         }
     }
-#else
+    #else
 
     /* Reference C code adapted from CMSIS-NN arm_avepool_q7_HWC.
      */
@@ -340,7 +340,7 @@ arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
         }
     }
 
-#endif
+    #endif
     return ARM_CMSIS_NN_SUCCESS;
 }
 

--- a/Source/SVDFunctions/arm_svdf_s8.c
+++ b/Source/SVDFunctions/arm_svdf_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_svdf_s8.c
  * Description:  S8 basic SVDF layer function
  *
- * $Date:        8 November 2022
- * $Revision:    V.5.0.0
+ * $Date:        5 January 2023
+ * $Revision:    V.5.1.0
  *
- * Target Processor:  Cortex-M processors
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -154,8 +154,8 @@ arm_cmsis_nn_status arm_svdf_s8(const cmsis_nn_context *input_ctx,
                     int32_t r1_1, r1_2, r2_1, r2_2;
                     v1 = read_and_pad_reordered(v1, &r1_1, &r1_2);
                     v2 = read_and_pad_reordered(v2, &r2_1, &r2_2);
-                    sum = __SMLAD(r1_1, r2_1, sum);
-                    sum = __SMLAD(r1_2, r2_2, sum);
+                    sum = SMLAD(r1_1, r2_1, sum);
+                    sum = SMLAD(r1_2, r2_2, sum);
                 }
 
                 // Process the remaining data

--- a/Source/SVDFunctions/arm_svdf_state_s16_s8.c
+++ b/Source/SVDFunctions/arm_svdf_state_s16_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_svdf_s8.c
  * Description:  S8 basic SVDF layer function with s16 state tensor
  *
- * $Date:        8 November 2022
- * $Revision:    V.3.0.0
+ * $Date:        5 January 2023
+ * $Revision:    V.3.1.0
  *
- * Target Processor:  Cortex-M processors
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -151,7 +151,7 @@ arm_cmsis_nn_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
                     int32_t r1 = arm_nn_read_q15x2_ia(&v1);
                     int32_t r2 = arm_nn_read_q15x2_ia(&v2);
 
-                    sum = __SMLAD(r1, r2, sum);
+                    sum = SMLAD(r1, r2, sum);
                 }
 
                 // Process the remaining data

--- a/Source/SoftmaxFunctions/arm_nn_softmax_common_s8.c
+++ b/Source/SoftmaxFunctions/arm_nn_softmax_common_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Arm Limited or its affiliates.
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nn_softmax_common_s8.c
  * Description:  Softmax with s8 input and output of s8 or s16.
  *
- * $Date:        17 March 2022
- * $Revision:    V.1.0.1
+ * $Date:        5 January 2023
+ * $Revision:    V.1.1.0
  *
- * Target Processor:  Cortex-M processors
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
 #include "arm_nnsupportfunctions.h"
@@ -89,7 +89,7 @@ void arm_nn_softmax_common_s8(const int8_t *input,
             }
         }
 
-        const int32_t headroom = __CLZ(sum);
+        const int32_t headroom = CLZ(sum);
         const int32_t shifted_scale = ONE_OVER1((sum > 0 ? sum << headroom : 0) - (1 << 31));
         int32_t bits_over_unit;
 

--- a/Source/SoftmaxFunctions/arm_softmax_s16.c
+++ b/Source/SoftmaxFunctions/arm_softmax_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Arm Limited or its affiliates.
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_softmax_s16.c
  * Description:  S16 softmax function
  *
- * $Date:        19 April 2022
- * $Revision:    V.2.0.0
+ * $Date:        5 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -84,7 +84,7 @@ arm_cmsis_nn_status arm_softmax_s16(const int16_t *input,
             sum += cached_exp_results[col];
         }
 
-        const int32_t headroom = __CLZ(sum);
+        const int32_t headroom = CLZ(sum);
 
         // Compute the reciprocal 1/sum
         const int32_t shifted_sum = (((sum) << (headroom - 1)) + (1 << 13)) >> 14;

--- a/Source/SoftmaxFunctions/arm_softmax_s8.c
+++ b/Source/SoftmaxFunctions/arm_softmax_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_softmax_s8.c
  * Description:  S8 softmax function
  *
- * $Date:        23 December 2022
- * $Revision:    V.2.1.1
+ * $Date:        5 January 2023
+ * $Revision:    V.2.2.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -36,7 +36,7 @@
 #if defined(ARM_MATH_MVEI) && !defined(ARM_GCC_12_2_ICE)
 static int32x4_t arm_exp_on_negative_values_mve_32x4(int32x4_t val)
 {
-#define SHIFT_START (24)
+    #define SHIFT_START (24)
     int32_t shift = SHIFT_START;
     int32x4_t mask;
 
@@ -49,12 +49,12 @@ static int32x4_t arm_exp_on_negative_values_mve_32x4(int32x4_t val)
     const int32x4_t op_2 = x + DIV_POW2_MVE(MUL_SAT_MVE(op_1, vdupq_n_s32(715827883)) + x2, 1);
     int32x4_t result = vdupq_n_s32(1895147668) + MUL_SAT_MVE(vdupq_n_s32(1895147668), op_2);
 
-#define SELECT_IF_NON_ZERO(x)                                                                                          \
-    {                                                                                                                  \
-        mve_pred16_t p = vcmpneq_n_s32(remainder & vdupq_n_s32(1 << shift++), 0);                                      \
-        mask = vmvnq_m_s32(vdupq_n_s32(0), vdupq_n_s32(0), p);                                                         \
-        result = SELECT_USING_MASK(mask, MUL_SAT_MVE(result, vdupq_n_s32(x)), result);                                 \
-    }
+    #define SELECT_IF_NON_ZERO(x)                                                                                      \
+        {                                                                                                              \
+            mve_pred16_t p = vcmpneq_n_s32(remainder & vdupq_n_s32(1 << shift++), 0);                                  \
+            mask = vmvnq_m_s32(vdupq_n_s32(0), vdupq_n_s32(0), p);                                                     \
+            result = SELECT_USING_MASK(mask, MUL_SAT_MVE(result, vdupq_n_s32(x)), result);                             \
+        }
 
     SELECT_IF_NON_ZERO(1672461947)
     SELECT_IF_NON_ZERO(1302514674)
@@ -64,7 +64,7 @@ static int32x4_t arm_exp_on_negative_values_mve_32x4(int32x4_t val)
     SELECT_IF_NON_ZERO(720401)
     SELECT_IF_NON_ZERO(242)
 
-#undef SELECT_IF_NON_ZERO
+    #undef SELECT_IF_NON_ZERO
 
     mve_pred16_t p = vcmpeqq_n_s32(val, 0);
     mask = vmvnq_m_s32(vdupq_n_s32(0), vdupq_n_s32(0), p);
@@ -93,8 +93,8 @@ void arm_softmax_s8(const int8_t *input,
 {
 #if defined(ARM_MATH_MVEI) && !defined(ARM_GCC_12_2_ICE)
 
-#define ACT_MIN ((int8_t)NN_Q7_MIN)
-#define ACT_MAX ((int8_t)NN_Q7_MAX)
+    #define ACT_MIN ((int8_t)NN_Q7_MIN)
+    #define ACT_MAX ((int8_t)NN_Q7_MAX)
 
     const int32_t mask = (1 << shift);
 
@@ -147,7 +147,7 @@ void arm_softmax_s8(const int8_t *input,
             }
         }
 
-        const int32_t headroom = __CLZ((uint32_t)sum);
+        const int32_t headroom = CLZ((uint32_t)sum);
         const int32_t bits_over_unit = ACCUM_BITS - headroom + 23;
         const int32_t shifted_scale = ONE_OVER1((sum > 0 ? sum << headroom : 0) - (1 << 31));
 

--- a/Source/SoftmaxFunctions/arm_softmax_u8.c
+++ b/Source/SoftmaxFunctions/arm_softmax_u8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2010-2020, 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_softmax_u8.c
  * Description:  U8 softmax function
  *
- * $Date:        09. October 2020
- * $Revision:    V.1.0.2
+ * $Date:        5 January 2023
+ * $Revision:    V.1.1.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -76,7 +76,7 @@ void arm_softmax_u8(const uint8_t *input,
             }
         }
 
-        const int32_t headroom = __CLZ((uint32_t)sum);
+        const int32_t headroom = CLZ((uint32_t)sum);
         const int32_t bits_over_unit = ACCUM_BITS - headroom + 23;
         const int32_t shifted_scale = ONE_OVER1((sum << headroom) - (1 << 31));
 

--- a/Tests/UnitTest/CMakeLists.txt
+++ b/Tests/UnitTest/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2019-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2019-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -32,6 +32,10 @@ add_compile_options(-Ofast
 
 option(BUILD_CMSIS_NN_UNIT "If building the unit tests from another project, i.e. \
 platform dependencies need to be provided externally." OFF)
+
+if (${CMSIS_PATH} STREQUAL "</path/to/CMSIS>")
+  message(FATAL_ERROR "CMSIS_PATH not set. Did you provide -DCMSIS_PATH=<path/to/CMSIS>?")
+endif()
 
 if(NOT BUILD_CMSIS_NN_UNIT)
     set(BUILD_CMSIS_NN_UNIT_TESTS_FOR_FVP_BASED_CORSTONE_300 ON)

--- a/Tests/UnitTest/README.md
+++ b/Tests/UnitTest/README.md
@@ -59,7 +59,7 @@ To use the tflite_runtime the script currently has to be modified.
 
 ## Getting started
 
-Note that CMSIS-NN has a dependency to [CMSIS](https://github.com/ARM-software/CMSIS_5) project.
+
 
 ### Using Arm Mbed OS supported hardware
 
@@ -73,8 +73,10 @@ Use the -h flag to get more info.
 
 ### Using FVP based on Arm Corstone-300 software
 
-The unit tests are built in the same as the CMSIS-NN library although in another location.
-Here is an example:
+The build for unit tests differs from the build of CMSIS-NN as a [standalone library](https://github.com/ARM-software/CMSIS-NN/blob/main/README.md#building-cmsis-nn-as-a-library) in that, there is a dependency to [CMSIS](https://github.com/ARM-software/CMSIS_5) project for the startup files from CMSIS-Core. This is specified by the mandatory CMSIS_PATH CMake argument.
+
+
+Here is an example for testing on Arm Cortex-M55:
 
 ```
 cd </path/to/CMSIS_NN/Tests/Unittest>
@@ -83,7 +85,6 @@ cd build
 cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain/arm-none-eabi-gcc.cmake -DTARGET_CPU=cortex-m55 -DCMSIS_PATH=</path/to/CMSIS>
 make
 ```
-Some more examples under: [Building CMSIS-NN as a library](https://github.com/ARM-software/CMSIS-NN/blob/main/README.md#building-cmsis-nn-as-a-library).
 
 This will build all unit tests. You can also just build a specific unit test only, for example:
 


### PR DESCRIPTION
arm_acle.h/arm_mve.h is included for ACLE intrinsics. For intricics that are not defined in a compiler's acle header, they are defined in CMSIS-NN

