### PR TITLE
Add new get buffer size functions for host compile

### DIFF
--- a/Include/arm_nnfunctions.h
+++ b/Include/arm_nnfunctions.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_nnfunctions.h
  * Description:  Public header file for CMSIS NN Library
  *
- * $Date:        21 November 2022
- * $Revision:    V.11.2.1
+ * $Date:        13 January 2023
+ * $Revision:    V.11.3.0
  *
- * Target Processor:  Arm Cortex-M Processors
+ * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
 
 /**
@@ -187,13 +187,39 @@ arm_cmsis_nn_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
  *                                filter dimensions
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  *
- * @return         The function returns  required buffer size(bytes)
+ * @return         The function returns required buffer size(bytes)
  *
  */
 int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params *conv_params,
                                                 const cmsis_nn_dims *input_dims,
                                                 const cmsis_nn_dims *filter_dims,
                                                 const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get the required buffer size for arm_convolve_wrapper_s8 for Arm(R) Helium Architecture case.
+ *        Refer to arm_convolve_wrapper_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_convolve_wrapper_s8_get_buffer_size().
+ *
+ */
+int32_t arm_convolve_wrapper_s8_get_buffer_size_mve(const cmsis_nn_conv_params *conv_params,
+                                                    const cmsis_nn_dims *input_dims,
+                                                    const cmsis_nn_dims *filter_dims,
+                                                    const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get the required buffer size for arm_convolve_wrapper_s8 for processors with DSP extension.
+ *        Refer to arm_convolve_wrapper_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_convolve_wrapper_s8_get_buffer_size().
+ *
+ */
+int32_t arm_convolve_wrapper_s8_get_buffer_size_dsp(const cmsis_nn_conv_params *conv_params,
+                                                    const cmsis_nn_dims *input_dims,
+                                                    const cmsis_nn_dims *filter_dims,
+                                                    const cmsis_nn_dims *output_dims);
 
 /**
  * @brief s16 convolution layer wrapper function with the main purpose to call the optimal kernel available in
@@ -235,7 +261,7 @@ arm_cmsis_nn_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
                                              int16_t *output_data);
 
 /**
- * @brief Get the required buffer size for arm_convolve_wrapper_s16
+ * @brief Get the required buffer size for arm_convolve_wrapper_s16.
  *
  * @param[in]      conv_params    Convolution parameters (e.g. strides, dilations, pads,...).
  *                                conv_params->input_offset  : Not used
@@ -245,13 +271,39 @@ arm_cmsis_nn_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
  *                                filter dimensions
  * @param[in]      output_dims    Output tensor dimensions. Format: [N, H, W, C_OUT]
  *
- * @return         The function returns  required buffer size(bytes)
+ * @return         The function returns required buffer size(bytes)
  *
  */
 int32_t arm_convolve_wrapper_s16_get_buffer_size(const cmsis_nn_conv_params *conv_params,
                                                  const cmsis_nn_dims *input_dims,
                                                  const cmsis_nn_dims *filter_dims,
                                                  const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get the required buffer size for arm_convolve_wrapper_s16 for for processors with DSP extension.
+ *        Refer to arm_convolve_wrapper_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_convolve_wrapper_s16_get_buffer_size().
+ *
+ */
+int32_t arm_convolve_wrapper_s16_get_buffer_size_dsp(const cmsis_nn_conv_params *conv_params,
+                                                     const cmsis_nn_dims *input_dims,
+                                                     const cmsis_nn_dims *filter_dims,
+                                                     const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get the required buffer size for arm_convolve_wrapper_s16 for Arm(R) Helium Architecture case.
+ *        Refer to arm_convolve_wrapper_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_convolve_wrapper_s16_get_buffer_size().
+ *
+ */
+int32_t arm_convolve_wrapper_s16_get_buffer_size_mve(const cmsis_nn_conv_params *conv_params,
+                                                     const cmsis_nn_dims *input_dims,
+                                                     const cmsis_nn_dims *filter_dims,
+                                                     const cmsis_nn_dims *output_dims);
 
 /**
  * @brief Basic s8 convolution function
@@ -298,7 +350,7 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
  * @param[in]       input_dims            Input (activation) tensor dimensions. Format: [N, H, W, C_IN]
  * @param[in]       filter_dims           Filter tensor dimensions. Format: [C_OUT, HK, WK, C_IN] where HK and WK
  * are the spatial filter dimensions
- * @return          The function returns  required buffer size(bytes)
+ * @return          The function returns required buffer size(bytes)
  *
  */
 int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims);
@@ -389,7 +441,7 @@ arm_cmsis_nn_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
  * @param[in]       input_dims    Input (activation) tensor dimensions. Format: [N, H, W, C_IN]
  * @param[in]       filter_dims   Filter tensor dimensions. Format: [C_OUT, HK, WK, C_IN] where HK and WK
  *                                are the spatial filter dimensions
- * @return          The function returns  required buffer size(bytes)
+ * @return          The function returns required buffer size(bytes)
  *
  */
 int32_t arm_convolve_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims);
@@ -552,7 +604,7 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
  * @param[in]       input_dims            Input (activation) tensor dimensions. Format: [N, H, W, C_IN]
  * @param[in]       filter_dims           Filter tensor dimensions. Format: [C_OUT, 1, WK, C_IN] where WK is the
  *                                        horizontal spatial filter dimension
- * @return          The function returns  required buffer size(bytes)
+ * @return          The function returns required buffer size(bytes)
  *
  */
 int32_t arm_convolve_1_x_n_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims);
@@ -622,6 +674,32 @@ int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size(const cmsis_nn_dw_conv_par
                                                       const cmsis_nn_dims *input_dims,
                                                       const cmsis_nn_dims *filter_dims,
                                                       const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_depthwise_conv_wrapper_s8() for processors with DSP extension.
+ *        Refer to arm_depthwise_conv_wrapper_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_depthwise_conv_wrapper_s8_get_buffer_size().
+ *
+ */
+int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size_dsp(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                          const cmsis_nn_dims *input_dims,
+                                                          const cmsis_nn_dims *filter_dims,
+                                                          const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_depthwise_conv_wrapper_s8() for Arm(R) Helium Architecture case.
+ *        Refer to arm_depthwise_conv_wrapper_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_depthwise_conv_wrapper_s8_get_buffer_size().
+ *
+ */
+int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size_mve(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                          const cmsis_nn_dims *input_dims,
+                                                          const cmsis_nn_dims *filter_dims,
+                                                          const cmsis_nn_dims *output_dims);
 
 /**
  * @brief Basic s8 depthwise convolution function that doesn't have any constraints on the input dimensions.
@@ -769,6 +847,32 @@ int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size(const cmsis_nn_dw_conv_pa
                                                        const cmsis_nn_dims *output_dims);
 
 /**
+ * @brief Get size of additional buffer required by arm_depthwise_conv_wrapper_s16() for processors with DSP extension.
+ *        Refer to arm_depthwise_conv_wrapper_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_depthwise_conv_wrapper_s16_get_buffer_size().
+ *
+ */
+int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size_dsp(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                           const cmsis_nn_dims *input_dims,
+                                                           const cmsis_nn_dims *filter_dims,
+                                                           const cmsis_nn_dims *output_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_depthwise_conv_wrapper_s16() for Arm(R) Helium Architecture
+ * case. Refer to arm_depthwise_conv_wrapper_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_depthwise_conv_wrapper_s16_get_buffer_size().
+ *
+ */
+int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size_mve(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                           const cmsis_nn_dims *input_dims,
+                                                           const cmsis_nn_dims *filter_dims,
+                                                           const cmsis_nn_dims *output_dims);
+
+/**
  * @brief Optimized s16 depthwise convolution function with constraint that in_channel equals out_channel.
  *        Refer arm_depthwise_conv_s16() for function argument details.
  *
@@ -805,7 +909,7 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
  * @param[in]       input_dims   Input (activation) tensor dimensions. Format: [1, H, W, C_IN]
  *                               Batch argument N is not used.
  * @param[in]       filter_dims  Filter tensor dimensions. Format: [1, H, W, C_OUT]
- * @return          The function returns  required buffer size in bytes
+ * @return          The function returns required buffer size in bytes
  *
  */
 int32_t arm_depthwise_conv_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims);
@@ -880,7 +984,7 @@ arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
  * @param[in]       input_dims   Input (activation) tensor dimensions. Format: [1, H, W, C_IN]
  *                               Batch argument N is not used.
  * @param[in]       filter_dims  Filter tensor dimensions. Format: [1, H, W, C_OUT]
- * @return          The function returns  required buffer size in bytes
+ * @return          The function returns required buffer size in bytes
  *
  */
 int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims);
@@ -946,13 +1050,32 @@ arm_cmsis_nn_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
                                            int8_t *output_data);
 
 /**
- * @brief Get the required buffer size for S8 basic fully-connected and
- * matrix multiplication layer function for TF Lite
+ * @brief Get size of additional buffer required by arm_fully_connected_s8().
  * @param[in]      filter_dims             dimension of filter
  * @return         The function returns    required buffer size in bytes
  *
  */
 int32_t arm_fully_connected_s8_get_buffer_size(const cmsis_nn_dims *filter_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_fully_connected_s8() for processors with DSP extension.
+ *        Refer to arm_fully_connected_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_fully_connected_s8_get_buffer_size().
+ *
+ */
+int32_t arm_fully_connected_s8_get_buffer_size_dsp(const cmsis_nn_dims *filter_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_fully_connected_s8() for Arm(R) Helium Architecture case.
+ *        Refer to arm_fully_connected_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_fully_connected_s8_get_buffer_size().
+ *
+ */
+int32_t arm_fully_connected_s8_get_buffer_size_mve(const cmsis_nn_dims *filter_dims);
 
 /**
  * @brief Basic s16 Fully Connected function.
@@ -1002,13 +1125,32 @@ arm_cmsis_nn_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
                                             int16_t *output_data);
 
 /**
- * @brief Get the required buffer size for S16 basic fully-connected and
- * matrix multiplication layer function for TF Lite
+ * @brief Get size of additional buffer required by arm_fully_connected_s16().
  * @param[in]      filter_dims             dimension of filter
  * @return         The function returns    required buffer size in bytes
  *
  */
 int32_t arm_fully_connected_s16_get_buffer_size(const cmsis_nn_dims *filter_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_fully_connected_s16() for processors with DSP extension.
+ *        Refer to arm_fully_connected_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_fully_connected_s16_get_buffer_size().
+ *
+ */
+int32_t arm_fully_connected_s16_get_buffer_size_dsp(const cmsis_nn_dims *filter_dims);
+
+/**
+ * @brief Get size of additional buffer required by arm_fully_connected_s16() for Arm(R) Helium Architecture case.
+ *        Refer to arm_fully_connected_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_fully_connected_s16_get_buffer_size().
+ *
+ */
+int32_t arm_fully_connected_s16_get_buffer_size_mve(const cmsis_nn_dims *filter_dims);
 
 /**
  * @defgroup groupElementwise Elementwise Functions
@@ -1240,10 +1382,30 @@ arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
  * @brief Get the required buffer size for S8 average pooling function
  * @param[in]       dim_dst_width         output tensor dimension
  * @param[in]       ch_src                number of input tensor channels
- * @return          The function returns  required buffer size in bytes
+ * @return          The function returns required buffer size in bytes
  *
  */
 int32_t arm_avgpool_s8_get_buffer_size(const int dim_dst_width, const int ch_src);
+
+/**
+ * @brief Get the required buffer size for S8 average pooling function for processors with DSP extension.
+ *        Refer to arm_avgpool_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_avgpool_s8_get_buffer_size().
+ *
+ */
+int32_t arm_avgpool_s8_get_buffer_size_dsp(const int dim_dst_width, const int ch_src);
+
+/**
+ * @brief Get the required buffer size for S8 average pooling function for Arm(R) Helium Architecture case.
+ *        Refer to arm_avgpool_s8_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_avgpool_s8_get_buffer_size().
+ *
+ */
+int32_t arm_avgpool_s8_get_buffer_size_mve(const int dim_dst_width, const int ch_src);
 
 /**
  * @brief s16 average pooling function.
@@ -1283,10 +1445,30 @@ arm_cmsis_nn_status arm_avgpool_s16(const cmsis_nn_context *ctx,
  * @brief Get the required buffer size for S16 average pooling function
  * @param[in]       dim_dst_width         output tensor dimension
  * @param[in]       ch_src                number of input tensor channels
- * @return          The function returns  required buffer size in bytes
+ * @return          The function returns required buffer size in bytes
  *
  */
 int32_t arm_avgpool_s16_get_buffer_size(const int dim_dst_width, const int ch_src);
+
+/**
+ * @brief Get the required buffer size for S16 average pooling function for processors with DSP extension.
+ *        Refer to arm_avgpool_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_avgpool_s16_get_buffer_size().
+ *
+ */
+int32_t arm_avgpool_s16_get_buffer_size_dsp(const int dim_dst_width, const int ch_src);
+
+/**
+ * @brief Get the required buffer size for S16 average pooling function for Arm(R) Helium Architecture case.
+ *        Refer to arm_avgpool_s16_get_buffer_size() for function argument details.
+ *
+ * @note       Intended for compilation on Host. If compiling for an Arm target, use
+ *             arm_avgpool_s16_get_buffer_size().
+ *
+ */
+int32_t arm_avgpool_s16_get_buffer_size_mve(const int dim_dst_width, const int ch_src);
 
 /**
  * @brief s8 max pooling function.
@@ -1772,6 +1954,8 @@ arm_cmsis_nn_status arm_svdf_state_s16_s8(const cmsis_nn_context *input_ctx,
  * Peephole connections, projection, clipping, combined input/forget gate and layer normalization are not supported.
  *
  * @param[in]   scratch_buffers                 Struct containing scratch buffers
+ *                                              Expected size for each scratch buffer is
+ *                                              lstm_dims->num_batches * lstm_dims->num_outputs.
  * @param[in]   input_data                      Pointer to input data
  * @param[in]   lstm_dims                       LSTM input parameters related to dimensions
  * @param[in]   input_to_input_weights          Input to input weights

--- a/Include/arm_nnfunctions.h
+++ b/Include/arm_nnfunctions.h
@@ -97,7 +97,7 @@
    * \section Copyright Copyright Notice
    *
    *
-   * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+   * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
    *
    *
    */

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        20 January 2023
- * $Revision:    V.14.2.0
+ * $Date:        30 January 2023
+ * $Revision:    V.14.3.0
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -40,6 +40,10 @@
 extern "C" {
 #endif
 
+#define USE_FAST_DW_CONV_S16_FUNCTION(dw_conv_params, filter_dims, input_dims)                                         \
+    (dw_conv_params->ch_mult == 1 && dw_conv_params->dilation.w == 1 && dw_conv_params->dilation.h == 1 &&             \
+     filter_dims->w * filter_dims->h < 512)
+
 #define LEFT_SHIFT(_shift) (_shift > 0 ? _shift : 0)
 #define RIGHT_SHIFT(_shift) (_shift > 0 ? 0 : -_shift)
 #define MASK_IF_ZERO(x) (x) == 0 ? ~0 : 0

--- a/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -21,7 +21,7 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        23 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.3.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
@@ -153,17 +153,6 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
 out:
     /* Return to application */
     return status;
-}
-
-int32_t arm_convolve_1_x_n_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
-{
-#if !defined(ARM_MATH_MVEI)
-    return arm_convolve_s8_get_buffer_size(input_dims, filter_dims);
-#else
-    (void)input_dims;
-    (void)filter_dims;
-    return 0;
-#endif
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -22,7 +22,7 @@
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
  * $Date:        30 January 2023
- * $Revision:    V.3.2.0
+ * $Revision:    V.3.3.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast s8 version of 1x1 convolution (non-square shape)
  *
- * $Date:        20 January 2023
- * $Revision:    V.3.0.4
+ * $Date:        30 January 2023
+ * $Revision:    V.3.1.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -90,12 +90,6 @@ arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims *input_dims)
-{
-    (void)input_dims;
-    return 0;
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
@@ -22,7 +22,7 @@
  * Description:  Optimized s16 version of convolution.
  *
  * $Date:        30 January 2023
- * $Revision:    V.2.1.0
+ * $Revision:    V.2.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_fast_s16.c
@@ -21,7 +21,7 @@
  * Title:        arm_convolve_fast_s16.c
  * Description:  Optimized s16 version of convolution.
  *
- * $Date:        5 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.2.1.0
  *
  * Target :  Arm(R) M-Profile Architecture
@@ -223,17 +223,6 @@ arm_cmsis_nn_status arm_convolve_fast_s16(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_convolve_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
-{
-#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int16_t);
-#else
-    (void)input_dims;
-    (void)filter_dims;
-    return 0;
-#endif
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s16.c
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_convolve_get_buffer_sizes_s16.c
+ * Description:  Collection of get buffer size functions for the various s16 convolution layer functions.
+ *
+ * $Date:        30 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "Internal/arm_nn_compiler.h"
+#include "arm_nnfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+__STATIC_INLINE int32_t arm_convolve_fast_s16_get_buffer_size_dsp(const cmsis_nn_dims *input_dims,
+                                                                  const cmsis_nn_dims *filter_dims)
+{
+    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int16_t);
+}
+
+int32_t arm_convolve_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    return arm_convolve_fast_s16_get_buffer_size_dsp(input_dims, filter_dims);
+#else
+    (void)input_dims;
+    (void)filter_dims;
+    return 0;
+#endif
+}
+
+int32_t arm_convolve_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
+{
+    (void)input_dims;
+    (void)filter_dims;
+    return 0;
+}
+
+/*
+ * Get the required buffer size for arm_convolve_wrapper_s16. This is the recommended function convolve wrapper s16
+ * function.
+ *
+ * Refer to header file for details.
+ *
+ */
+int32_t arm_convolve_wrapper_s16_get_buffer_size(const cmsis_nn_conv_params *conv_params,
+                                                 const cmsis_nn_dims *input_dims,
+                                                 const cmsis_nn_dims *filter_dims,
+                                                 const cmsis_nn_dims *output_dims)
+{
+
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    return arm_convolve_wrapper_s16_get_buffer_size_dsp(conv_params, input_dims, filter_dims, output_dims);
+#else
+    (void)conv_params;
+    (void)output_dims;
+
+    // MVE and scalar implementation have same buffer requirements
+    return arm_convolve_s16_get_buffer_size(input_dims, filter_dims);
+#endif
+}
+
+int32_t arm_convolve_wrapper_s16_get_buffer_size_dsp(const cmsis_nn_conv_params *conv_params,
+                                                     const cmsis_nn_dims *input_dims,
+                                                     const cmsis_nn_dims *filter_dims,
+                                                     const cmsis_nn_dims *output_dims)
+{
+    (void)output_dims;
+
+    if (filter_dims->w * filter_dims->h * input_dims->c < 512 &&
+        (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
+    {
+        return arm_convolve_fast_s16_get_buffer_size_dsp(input_dims, filter_dims);
+    }
+    else
+    {
+
+        return arm_convolve_s16_get_buffer_size(input_dims, filter_dims);
+    }
+}
+
+int32_t arm_convolve_wrapper_s16_get_buffer_size_mve(const cmsis_nn_conv_params *conv_params,
+                                                     const cmsis_nn_dims *input_dims,
+                                                     const cmsis_nn_dims *filter_dims,
+                                                     const cmsis_nn_dims *output_dims)
+{
+    return arm_convolve_wrapper_s16_get_buffer_size(conv_params, input_dims, filter_dims, output_dims);
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_convolve_get_buffer_sizes_s8.c
+ * Description:  Collection of get buffer size functions for the various s8 convolution layer functions.
+ *
+ * $Date:        30 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "Internal/arm_nn_compiler.h"
+#include "arm_nnfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+__STATIC_INLINE int32_t arm_convolve_s8_get_buffer_size_mve(const cmsis_nn_dims *input_dims,
+                                                            const cmsis_nn_dims *filter_dims)
+{
+    int32_t col_length = input_dims->c * filter_dims->w * filter_dims->h;
+    // Get number of complete int16 lanes(multiple of 8) for given col_length. This is dependent on
+    // implementation of  arm_nn_mat_mult_s8
+    col_length = (col_length + 7) / 8;
+    // 4 -> number of im2col buffers, 8 -> 8 elements per Q register
+    return 4 * col_length * 8 * (int32_t)sizeof(int8_t);
+}
+
+__STATIC_INLINE int32_t arm_convolve_1_x_n_s8_get_buffer_size_mve(const cmsis_nn_dims *input_dims,
+                                                                  const cmsis_nn_dims *filter_dims)
+{
+    (void)input_dims;
+    (void)filter_dims;
+    return 0;
+}
+
+int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
+{
+#if defined(ARM_MATH_MVEI)
+    return arm_convolve_s8_get_buffer_size_mve(input_dims, filter_dims);
+#else
+    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int16_t);
+#endif
+}
+
+int32_t arm_convolve_1_x_n_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
+{
+#if !defined(ARM_MATH_MVEI)
+    return arm_convolve_s8_get_buffer_size(input_dims, filter_dims);
+#else
+    return arm_convolve_1_x_n_s8_get_buffer_size_mve(input_dims, filter_dims);
+#endif
+}
+
+int32_t arm_convolve_1x1_s8_fast_get_buffer_size(const cmsis_nn_dims *input_dims)
+{
+    (void)input_dims;
+    return 0;
+}
+
+/*
+ * Get the required buffer size for arm_convolve_wrapper_s8. This is the recommended function convolve wrapper s8
+ * function.
+ *
+ * Refer to header file for details.
+ *
+ */
+int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params *conv_params,
+                                                const cmsis_nn_dims *input_dims,
+                                                const cmsis_nn_dims *filter_dims,
+                                                const cmsis_nn_dims *output_dims)
+{
+#if defined(ARM_MATH_MVEI)
+    return arm_convolve_wrapper_s8_get_buffer_size_mve(conv_params, input_dims, filter_dims, output_dims);
+#else
+
+    if ((conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
+        (filter_dims->h == 1) && (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
+    {
+        if ((conv_params->stride.w == 1) && (conv_params->stride.h == 1))
+        {
+            return arm_convolve_1x1_s8_fast_get_buffer_size(input_dims);
+        }
+        else
+        {
+            return 0;
+        }
+    }
+    else if ((input_dims->h == 1) && (output_dims->w % 4 == 0) && (conv_params->dilation.w == 1) &&
+             (filter_dims->h == 1))
+    {
+        return arm_convolve_1_x_n_s8_get_buffer_size(input_dims, filter_dims);
+    }
+    else
+    {
+        return arm_convolve_s8_get_buffer_size(input_dims, filter_dims);
+    }
+#endif
+}
+
+int32_t arm_convolve_wrapper_s8_get_buffer_size_mve(const cmsis_nn_conv_params *conv_params,
+                                                    const cmsis_nn_dims *input_dims,
+                                                    const cmsis_nn_dims *filter_dims,
+                                                    const cmsis_nn_dims *output_dims)
+{
+    if ((conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
+        (filter_dims->h == 1) && (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
+    {
+        if ((conv_params->stride.w == 1) && (conv_params->stride.h == 1))
+        {
+            return arm_convolve_1x1_s8_fast_get_buffer_size(input_dims);
+        }
+        else
+        {
+            return 0;
+        }
+    }
+    else if ((input_dims->h == 1) && (output_dims->w % 4 == 0) && (conv_params->dilation.w == 1) &&
+             (filter_dims->h == 1))
+    {
+        return arm_convolve_1_x_n_s8_get_buffer_size_mve(input_dims, filter_dims);
+    }
+    else
+    {
+        return arm_convolve_s8_get_buffer_size_mve(input_dims, filter_dims);
+    }
+}
+
+int32_t arm_convolve_wrapper_s8_get_buffer_size_dsp(const cmsis_nn_conv_params *conv_params,
+                                                    const cmsis_nn_dims *input_dims,
+                                                    const cmsis_nn_dims *filter_dims,
+                                                    const cmsis_nn_dims *output_dims)
+{
+    return arm_convolve_wrapper_s8_get_buffer_size(conv_params, input_dims, filter_dims, output_dims);
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/ConvolutionFunctions/arm_convolve_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_s16.c
@@ -21,7 +21,7 @@
  * Title:        arm_convolve_s16.c
  * Description:  s16 version of convolution using symmetric quantization.
  *
- * $Date:        12 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.2.1.0
  *
  * Target :  Arm(R) M-Profile Architecture

--- a/Source/ConvolutionFunctions/arm_convolve_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_convolve_s16.c
  * Description:  s16 version of convolution using symmetric quantization.
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.0.1
+ * $Date:        12 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -142,13 +142,6 @@ arm_cmsis_nn_status arm_convolve_s16(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_convolve_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
-{
-    (void)input_dims;
-    (void)filter_dims;
-    return 0;
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_s8.c
  * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        5 January 2023
- * $Revision:    V.3.1.0
+ * $Date:        30 January 2023
+ * $Revision:    V.3.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -318,20 +318,6 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_convolve_s8_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
-{
-#if defined(ARM_MATH_MVEI)
-    int32_t col_length = input_dims->c * filter_dims->w * filter_dims->h;
-    // Get number of complete int16 lanes(multiple of 8) for given col_length. This is dependent on
-    // implementation of  arm_nn_mat_mult_s8
-    col_length = (col_length + 7) / 8;
-    // 4 -> number of im2col buffers, 8 -> 8 elements per Q register
-    return 4 * col_length * 8 * (int32_t)sizeof(int8_t);
-#else
-    return (2 * input_dims->c * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int16_t);
-#endif
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_convolve_wrapper_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_wrapper_s16.c
@@ -22,7 +22,7 @@
  * Description:  s16 convolution layer wrapper function with the main purpose to call the optimal kernel available in
  * cmsis-nn to perform the convolution.
  *
- * $Date:        12 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.2.1.0
  *
  * Target :  Arm(R) M-Profile Architecture

--- a/Source/ConvolutionFunctions/arm_convolve_wrapper_s16.c
+++ b/Source/ConvolutionFunctions/arm_convolve_wrapper_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2021-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2021-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  s16 convolution layer wrapper function with the main purpose to call the optimal kernel available in
  * cmsis-nn to perform the convolution.
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.0.1
+ * $Date:        12 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -101,27 +101,6 @@ arm_cmsis_nn_status arm_convolve_wrapper_s16(const cmsis_nn_context *ctx,
                             bias_data,
                             output_dims,
                             output_data);
-#endif
-}
-
-int32_t arm_convolve_wrapper_s16_get_buffer_size(const cmsis_nn_conv_params *conv_params,
-                                                 const cmsis_nn_dims *input_dims,
-                                                 const cmsis_nn_dims *filter_dims,
-                                                 const cmsis_nn_dims *output_dims)
-{
-    (void)conv_params;
-    (void)output_dims;
-
-#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    if (filter_dims->w * filter_dims->h * input_dims->c < 512 &&
-        (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
-    {
-        return arm_convolve_fast_s16_get_buffer_size(input_dims, filter_dims);
-    }
-
-    return arm_convolve_s16_get_buffer_size(input_dims, filter_dims);
-#else
-    return arm_convolve_s16_get_buffer_size(input_dims, filter_dims);
 #endif
 }
 

--- a/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  s8 convolution layer wrapper function with the main purpose to call the optimal kernel available in
  * cmsis-nn to perform the convolution.
  *
- * $Date:        3 November 2022
- * $Revision:    V.2.2.0
+ * $Date:        11 January 2023
+ * $Revision:    V.2.3.0
  *
- * Target Processor:  Arm Cortex-M Processors
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -118,34 +118,6 @@ arm_cmsis_nn_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
                                bias_data,
                                output_dims,
                                output_data);
-    }
-}
-
-int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params *conv_params,
-                                                const cmsis_nn_dims *input_dims,
-                                                const cmsis_nn_dims *filter_dims,
-                                                const cmsis_nn_dims *output_dims)
-{
-    if ((conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
-        (filter_dims->h == 1) && (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
-    {
-        if ((conv_params->stride.w == 1) && (conv_params->stride.h == 1))
-        {
-            return arm_convolve_1x1_s8_fast_get_buffer_size(input_dims);
-        }
-        else
-        {
-            return 0;
-        }
-    }
-    else if ((input_dims->h == 1) && (output_dims->w % 4 == 0) && (conv_params->dilation.w == 1) &&
-             (filter_dims->h == 1))
-    {
-        return arm_convolve_1_x_n_s8_get_buffer_size(input_dims, filter_dims);
-    }
-    else
-    {
-        return arm_convolve_s8_get_buffer_size(input_dims, filter_dims);
     }
 }
 

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_fast_s16.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_fast_s16.c
@@ -23,7 +23,7 @@
  *               channel multiplier of 1.
  *
  * $Date:        30 January 2023
- * $Revision:    V.1.2.0
+ * $Revision:    V.1.3.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_fast_s16.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_fast_s16.c
@@ -22,7 +22,7 @@
  * Description:  Optimized s16 depthwise separable convolution function for
  *               channel multiplier of 1.
  *
- * $Date:        5 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.1.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
@@ -444,22 +444,6 @@ arm_cmsis_nn_status arm_depthwise_conv_fast_s16(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_depthwise_conv_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
-{
-#if defined(ARM_MATH_DSP)
-    #if defined(ARM_MATH_MVEI)
-    /* The + 8 accounts for a worst case out of bounds read of the lhs buffers in the *_nt_t_* function.  */
-    return 4 * input_dims->c * filter_dims->w * filter_dims->h * sizeof(int16_t) + 8;
-    #else // ARM_MATH_DSP
-    return input_dims->c * filter_dims->w * filter_dims->h * sizeof(int16_t);
-    #endif
-#else
-    (void)input_dims;
-    (void)filter_dims;
-    return 0;
-#endif
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_get_buffer_sizes_s16.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_get_buffer_sizes_s16.c
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_depthwise_conv_get_buffer_sizes_s16.c
+ * Description:  Collection of get buffer size functions for the various s16 convolution layer functions.
+ *
+ * $Date:        13 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+#include "arm_nnsupportfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+__STATIC_INLINE int32_t arm_depthwise_conv_fast_s16_get_buffer_size_mve(const cmsis_nn_dims *input_dims,
+                                                                        const cmsis_nn_dims *filter_dims)
+{
+    /* The + 8 accounts for a worst case out of bounds read of the lhs buffers in the *_nt_t_* function.  */
+    return 4 * input_dims->c * filter_dims->w * filter_dims->h * sizeof(int16_t) + 8;
+}
+
+__STATIC_INLINE int32_t arm_depthwise_conv_fast_s16_get_buffer_size_dsp(const cmsis_nn_dims *input_dims,
+                                                                        const cmsis_nn_dims *filter_dims)
+{
+    return input_dims->c * filter_dims->w * filter_dims->h * sizeof(int16_t);
+}
+
+int32_t arm_depthwise_conv_fast_s16_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
+{
+#if defined(ARM_MATH_DSP)
+    #if defined(ARM_MATH_MVEI)
+    return arm_depthwise_conv_fast_s16_get_buffer_size_mve(input_dims, filter_dims);
+    #else // ARM_MATH_DSP
+    return arm_depthwise_conv_fast_s16_get_buffer_size_dsp(input_dims, filter_dims);
+    #endif
+#else
+    (void)input_dims;
+    (void)filter_dims;
+    return 0;
+#endif
+}
+
+int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                       const cmsis_nn_dims *input_dims,
+                                                       const cmsis_nn_dims *filter_dims,
+                                                       const cmsis_nn_dims *output_dims)
+{
+    (void)output_dims;
+
+    int32_t size = 0;
+
+    if (USE_FAST_DW_CONV_S16_FUNCTION(dw_conv_params, filter_dims, input_dims))
+    {
+        size = arm_depthwise_conv_fast_s16_get_buffer_size(input_dims, filter_dims);
+    }
+
+    return size;
+}
+
+int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size_mve(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                           const cmsis_nn_dims *input_dims,
+                                                           const cmsis_nn_dims *filter_dims,
+                                                           const cmsis_nn_dims *output_dims)
+{
+    (void)output_dims;
+
+    int32_t size = 0;
+
+    if (USE_FAST_DW_CONV_S16_FUNCTION(dw_conv_params, filter_dims, input_dims))
+    {
+        size = arm_depthwise_conv_fast_s16_get_buffer_size_mve(input_dims, filter_dims);
+    }
+
+    return size;
+}
+
+int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size_dsp(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                           const cmsis_nn_dims *input_dims,
+                                                           const cmsis_nn_dims *filter_dims,
+                                                           const cmsis_nn_dims *output_dims)
+{
+    (void)output_dims;
+
+    int32_t size = 0;
+
+    if (USE_FAST_DW_CONV_S16_FUNCTION(dw_conv_params, filter_dims, input_dims))
+    {
+        size = arm_depthwise_conv_fast_s16_get_buffer_size_dsp(input_dims, filter_dims);
+    }
+
+    return size;
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_get_buffer_sizes_s8.c
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_depthwise_conv_get_buffer_sizes_s8.c
+ * Description:  Collection of get buffer size functions for the various s8 convolution layer functions.
+ *
+ * $Date:        20 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+#include "arm_nnsupportfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+__STATIC_INLINE int32_t arm_depthwise_conv_s8_opt_get_buffer_size_mve(const cmsis_nn_dims *input_dims,
+                                                                      const cmsis_nn_dims *filter_dims)
+{
+    (void)input_dims;
+    return (4 * CH_IN_BLOCK_MVE * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int8_t);
+}
+
+__STATIC_INLINE int32_t arm_depthwise_conv_s8_opt_get_buffer_size_dsp(const cmsis_nn_dims *input_dims,
+                                                                      const cmsis_nn_dims *filter_dims)
+{
+    return (input_dims->c * filter_dims->w * filter_dims->h) * sizeof(int16_t);
+}
+
+int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
+{
+#if defined(ARM_MATH_MVEI)
+    return arm_depthwise_conv_s8_opt_get_buffer_size_mve(input_dims, filter_dims);
+#elif defined(ARM_MATH_DSP)
+    return arm_depthwise_conv_s8_opt_get_buffer_size_dsp(input_dims, filter_dims);
+#else
+    (void)input_dims;
+    (void)filter_dims;
+    return 0;
+#endif
+}
+
+int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                      const cmsis_nn_dims *input_dims,
+                                                      const cmsis_nn_dims *filter_dims,
+                                                      const cmsis_nn_dims *output_dims)
+{
+    int32_t size = 0;
+
+    if (input_dims->c == output_dims->c && input_dims->n == 1 && dw_conv_params->dilation.w == 1 &&
+        dw_conv_params->dilation.h == 1)
+    {
+#if !defined(ARM_MATH_MVEI)
+        if (filter_dims->w == 3 && filter_dims->h == 3 && dw_conv_params->padding.h <= 1 &&
+            dw_conv_params->padding.w <= 1)
+        {
+            return size;
+        }
+#endif
+        size = arm_depthwise_conv_s8_opt_get_buffer_size(input_dims, filter_dims);
+    }
+
+    return size;
+}
+
+int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size_dsp(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                          const cmsis_nn_dims *input_dims,
+                                                          const cmsis_nn_dims *filter_dims,
+                                                          const cmsis_nn_dims *output_dims)
+{
+    int32_t size = 0;
+
+    if (input_dims->c == output_dims->c && input_dims->n == 1 && dw_conv_params->dilation.w == 1 &&
+        dw_conv_params->dilation.h == 1)
+    {
+        if (filter_dims->w == 3 && filter_dims->h == 3 && dw_conv_params->padding.h <= 1 &&
+            dw_conv_params->padding.w <= 1)
+        {
+            return size;
+        }
+        size = arm_depthwise_conv_s8_opt_get_buffer_size_dsp(input_dims, filter_dims);
+    }
+
+    return size;
+}
+
+int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size_mve(const cmsis_nn_dw_conv_params *dw_conv_params,
+                                                          const cmsis_nn_dims *input_dims,
+                                                          const cmsis_nn_dims *filter_dims,
+                                                          const cmsis_nn_dims *output_dims)
+{
+    int32_t size = 0;
+
+    if (input_dims->c == output_dims->c && input_dims->n == 1 && dw_conv_params->dilation.w == 1 &&
+        dw_conv_params->dilation.h == 1)
+    {
+        size = arm_depthwise_conv_s8_opt_get_buffer_size_mve(input_dims, filter_dims);
+    }
+
+    return size;
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -23,7 +23,7 @@
  *               channel multiplier of 1.
  *
  * $Date:        30 January 2023
- * $Revision:    V.3.2.0
+ * $Revision:    V.3.3.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
@@ -22,7 +22,7 @@
  * Description:  Optimized s8 depthwise separable convolution function for
  *               channel multiplier of 1.
  *
- * $Date:        5 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.3.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
@@ -440,20 +440,6 @@ arm_cmsis_nn_status arm_depthwise_conv_s8_opt(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_depthwise_conv_s8_opt_get_buffer_size(const cmsis_nn_dims *input_dims, const cmsis_nn_dims *filter_dims)
-{
-#if defined(ARM_MATH_MVEI)
-    (void)input_dims;
-    return (4 * CH_IN_BLOCK_MVE * filter_dims->w * filter_dims->h) * (int32_t)sizeof(int8_t);
-#elif defined(ARM_MATH_DSP)
-    return (input_dims->c * filter_dims->w * filter_dims->h) * sizeof(int16_t);
-#else
-    (void)input_dims;
-    (void)filter_dims;
-    return 0;
-#endif
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s16.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s16.c
@@ -22,18 +22,15 @@
  * Description:  Wrapper API to select appropriate depthwise conv API based
  *               on dimensions.
  *
- * $Date:        18 January 2023
- * $Revision:    V.1.0.3
+ * $Date:        20 January 2023
+ * $Revision:    V.1.1.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
 #include "arm_nnfunctions.h"
-
-#define USE_FAST_DW_CONV_FUNCTION(dw_conv_params, filter_dims, input_dims)                                             \
-    (dw_conv_params->ch_mult == 1 && dw_conv_params->dilation.w == 1 && dw_conv_params->dilation.h == 1 &&             \
-     filter_dims->w * filter_dims->h < 512)
+#include "arm_nnsupportfunctions.h"
 
 /**
  *  @ingroup Public
@@ -64,7 +61,7 @@ arm_cmsis_nn_status arm_depthwise_conv_wrapper_s16(const cmsis_nn_context *ctx,
 {
     arm_cmsis_nn_status status = ARM_CMSIS_NN_SUCCESS;
 
-    if (USE_FAST_DW_CONV_FUNCTION(dw_conv_params, filter_dims, input_dims))
+    if (USE_FAST_DW_CONV_S16_FUNCTION(dw_conv_params, filter_dims, input_dims))
     {
         status = arm_depthwise_conv_fast_s16(ctx,
                                              dw_conv_params,
@@ -95,22 +92,6 @@ arm_cmsis_nn_status arm_depthwise_conv_wrapper_s16(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return status;
-}
-
-int32_t arm_depthwise_conv_wrapper_s16_get_buffer_size(const cmsis_nn_dw_conv_params *dw_conv_params,
-                                                       const cmsis_nn_dims *input_dims,
-                                                       const cmsis_nn_dims *filter_dims,
-                                                       const cmsis_nn_dims *output_dims)
-{
-    (void)output_dims;
-    int32_t size = 0;
-
-    if (USE_FAST_DW_CONV_FUNCTION(dw_conv_params, filter_dims, input_dims))
-    {
-        size = arm_depthwise_conv_fast_s16_get_buffer_size(input_dims, filter_dims);
-    }
-
-    return size;
 }
 
 /**

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,10 +22,10 @@
  * Description:  Wrapper API to select appropriate depthwise conv API based
  *               on dimensions.
  *
- * $Date:        23 November 2022
- * $Revision:    V.2.0.2
+ * $Date:        13 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M CPUs
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -111,29 +111,6 @@ arm_cmsis_nn_status arm_depthwise_conv_wrapper_s8(const cmsis_nn_context *ctx,
 
     /* Return to application */
     return status;
-}
-
-int32_t arm_depthwise_conv_wrapper_s8_get_buffer_size(const cmsis_nn_dw_conv_params *dw_conv_params,
-                                                      const cmsis_nn_dims *input_dims,
-                                                      const cmsis_nn_dims *filter_dims,
-                                                      const cmsis_nn_dims *output_dims)
-{
-    int32_t size = 0;
-
-    if (input_dims->c == output_dims->c && input_dims->n == 1 && dw_conv_params->dilation.w == 1 &&
-        dw_conv_params->dilation.h == 1)
-    {
-#if !defined(ARM_MATH_MVEI)
-        if (filter_dims->w == 3 && filter_dims->h == 3 && dw_conv_params->padding.h <= 1 &&
-            dw_conv_params->padding.w <= 1)
-        {
-            return size;
-        }
-#endif
-        size = arm_depthwise_conv_s8_opt_get_buffer_size(input_dims, filter_dims);
-    }
-
-    return size;
 }
 
 /**

--- a/Source/FullyConnectedFunctions/CMakeLists.txt
+++ b/Source/FullyConnectedFunctions/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Arm Limited.
+# SPDX-FileCopyrightText: Copyright 2019-2021, 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,5 +17,5 @@
 #
 
 file(GLOB SRC "./*_s8.c")
-target_sources(cmsis-nn PRIVATE ${SRC} arm_fully_connected_s16.c)
-
+file(GLOB SRC_S16 "./*_s16*.c")
+target_sources(cmsis-nn PRIVATE ${SRC} ${SRC_S16})

--- a/Source/FullyConnectedFunctions/arm_fully_connected_get_buffer_sizes_s16.c
+++ b/Source/FullyConnectedFunctions/arm_fully_connected_get_buffer_sizes_s16.c
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_fully_connected_get_buffer_sizes_s16.c
+ * Description:  Collection of get buffer size functions for fully connected s16 layer function.
+ *
+ * $Date:        13 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+int32_t arm_fully_connected_s16_get_buffer_size(const cmsis_nn_dims *filter_dims)
+{
+    (void)filter_dims;
+    return 0;
+}
+
+int32_t arm_fully_connected_s16_get_buffer_size_dsp(const cmsis_nn_dims *filter_dims)
+{
+    return arm_fully_connected_s16_get_buffer_size(filter_dims);
+}
+
+int32_t arm_fully_connected_s16_get_buffer_size_mve(const cmsis_nn_dims *filter_dims)
+{
+    return arm_fully_connected_s16_get_buffer_size(filter_dims);
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/FullyConnectedFunctions/arm_fully_connected_get_buffer_sizes_s8.c
+++ b/Source/FullyConnectedFunctions/arm_fully_connected_get_buffer_sizes_s8.c
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_fully_connected_get_buffer_sizes_s8.c
+ * Description:  Collection of get buffer size functions for fully connected s8 layer function.
+ *
+ * $Date:        13 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+int32_t arm_fully_connected_s8_get_buffer_size(const cmsis_nn_dims *filter_dims)
+{
+    (void)filter_dims;
+    return 0;
+}
+
+int32_t arm_fully_connected_s8_get_buffer_size_dsp(const cmsis_nn_dims *filter_dims)
+{
+    return arm_fully_connected_s8_get_buffer_size(filter_dims);
+}
+
+int32_t arm_fully_connected_s8_get_buffer_size_mve(const cmsis_nn_dims *filter_dims)
+{
+    return arm_fully_connected_s8_get_buffer_size(filter_dims);
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/FullyConnectedFunctions/arm_fully_connected_s16.c
+++ b/Source/FullyConnectedFunctions/arm_fully_connected_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_fully_connected_s16
  * Description:  Fully connected function compatible with TF Lite.
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.0.1
+ * $Date:        13 January 2023
+ * $Revision:    V.2.1.0
  *
- * Target Processor:  Cortex-M and Cortex-A cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -84,12 +84,6 @@ arm_cmsis_nn_status arm_fully_connected_s16(const cmsis_nn_context *ctx,
     }
 
     return (ARM_CMSIS_NN_SUCCESS);
-}
-
-int32_t arm_fully_connected_s16_get_buffer_size(const cmsis_nn_dims *filter_dims)
-{
-    (void)filter_dims;
-    return 0;
 }
 
 /**

--- a/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
+++ b/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,10 +21,10 @@
  * Title:        arm_fully_connected_s8
  * Description:  Fully connected function compatible with TF Lite.
  *
- * $Date:        8 November 2022
- * $Revision:    V.5.0.0
+ * $Date:        13 January 2023
+ * $Revision:    V.5.1.0
  *
- * Target Processor:  Cortex-M and Cortex-A cores
+ * Target :  Arm(R) M-Profile Architecture
  *
  * -------------------------------------------------------------------- */
 
@@ -85,12 +85,6 @@ arm_cmsis_nn_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
         batch_cnt--;
     }
     return (ARM_CMSIS_NN_SUCCESS);
-}
-
-int32_t arm_fully_connected_s8_get_buffer_size(const cmsis_nn_dims *filter_dims)
-{
-    (void)filter_dims;
-    return 0;
 }
 
 /**

--- a/Source/PoolingFunctions/arm_avgpool_get_buffer_sizes_s16.c
+++ b/Source/PoolingFunctions/arm_avgpool_get_buffer_sizes_s16.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_avgpool_get_buffer_sizes_s16.c
+ * Description:  Collection of get buffer size functions for avgpool s16 layer function.
+ *
+ * $Date:        13 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+int32_t arm_avgpool_s16_get_buffer_size(const int output_x, const int ch_src)
+{
+#if defined(ARM_MATH_MVEI)
+    return arm_avgpool_s16_get_buffer_size_mve(output_x, ch_src);
+#elif defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    return arm_avgpool_s16_get_buffer_size_dsp(output_x, ch_src);
+#else
+    (void)output_x;
+    (void)ch_src;
+    return 0;
+#endif
+}
+
+int32_t arm_avgpool_s16_get_buffer_size_dsp(const int output_x, const int ch_src)
+{
+    (void)output_x;
+    return (ch_src * sizeof(int32_t));
+}
+
+int32_t arm_avgpool_s16_get_buffer_size_mve(const int output_x, const int ch_src)
+{
+    (void)output_x;
+    (void)ch_src;
+
+    return 0;
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/PoolingFunctions/arm_avgpool_get_buffer_sizes_s8.c
+++ b/Source/PoolingFunctions/arm_avgpool_get_buffer_sizes_s8.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ----------------------------------------------------------------------
+ * Project:      CMSIS NN Library
+ * Title:        arm_avgpool_get_buffer_sizes_s8.c
+ * Description:  Collection of get buffer size functions for avgpool s8 layer function.
+ *
+ * $Date:        25 January 2023
+ * $Revision:    V.1.0.0
+ *
+ * Target :  Arm(R) M-Profile Architecture
+ *
+ * -------------------------------------------------------------------- */
+
+#include "arm_nnfunctions.h"
+
+/**
+ *  @ingroup Public
+ */
+
+/**
+ * @addtogroup NNConv
+ * @{
+ */
+
+int32_t arm_avgpool_s8_get_buffer_size(const int output_x, const int ch_src)
+{
+#if defined(ARM_MATH_MVEI)
+    return arm_avgpool_s8_get_buffer_size_mve(output_x, ch_src);
+#elif defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    return arm_avgpool_s8_get_buffer_size_dsp(output_x, ch_src);
+#else
+    (void)output_x;
+    (void)ch_src;
+    return 0;
+#endif
+}
+
+int32_t arm_avgpool_s8_get_buffer_size_dsp(const int output_x, const int ch_src)
+{
+    (void)output_x;
+    return (ch_src * sizeof(int32_t));
+}
+
+int32_t arm_avgpool_s8_get_buffer_size_mve(const int output_x, const int ch_src)
+{
+    (void)output_x;
+    (void)ch_src;
+
+    return 0;
+}
+
+/**
+ * @} end of NNConv group
+ */

--- a/Source/PoolingFunctions/arm_avgpool_s16.c
+++ b/Source/PoolingFunctions/arm_avgpool_s16.c
@@ -21,7 +21,7 @@
  * Title:        arm_avgpool_s16.c
  * Description:  Pooling function implementations
  *
- * $Date:        5 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.2.3.0
  *
  * Target :  Arm(R) M-Profile Architecture
@@ -289,17 +289,6 @@ arm_cmsis_nn_status arm_avgpool_s16(const cmsis_nn_context *ctx,
 #endif
 
     return ARM_CMSIS_NN_SUCCESS;
-}
-
-int32_t arm_avgpool_s16_get_buffer_size(const int output_x, const int ch_src)
-{
-    (void)output_x;
-#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    return (ch_src * (int32_t)sizeof(int32_t));
-#else
-    (void)ch_src;
-#endif
-    return 0;
 }
 
 /**

--- a/Source/PoolingFunctions/arm_avgpool_s16.c
+++ b/Source/PoolingFunctions/arm_avgpool_s16.c
@@ -22,7 +22,7 @@
  * Description:  Pooling function implementations
  *
  * $Date:        30 January 2023
- * $Revision:    V.2.3.0
+ * $Revision:    V.2.4.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -21,7 +21,7 @@
  * Title:        arm_avgpool_s8.c
  * Description:  Pooling function implementations
  *
- * $Date:        5 January 2023
+ * $Date:        30 January 2023
  * $Revision:    V.3.1.0
  *
  * Target :  Arm(R) M-Profile Architecture
@@ -346,17 +346,6 @@ arm_cmsis_nn_status arm_avgpool_s8(const cmsis_nn_context *ctx,
 
 #endif /* ARM_MATH_MVEI */
 
-int32_t arm_avgpool_s8_get_buffer_size(const int output_x, const int ch_src)
-{
-    (void)output_x;
-
-#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
-    return (ch_src * sizeof(int32_t));
-#else
-    (void)ch_src;
-    return 0;
-#endif
-}
 /**
  * @} end of Pooling group
  */

--- a/Source/PoolingFunctions/arm_avgpool_s8.c
+++ b/Source/PoolingFunctions/arm_avgpool_s8.c
@@ -22,7 +22,7 @@
  * Description:  Pooling function implementations
  *
  * $Date:        30 January 2023
- * $Revision:    V.3.1.0
+ * $Revision:    V.3.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Tests/UnitTest/TestCases/test_arm_avgpool_s16/Unity/unity_test_arm_avgpool_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_avgpool_s16/Unity/unity_test_arm_avgpool_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Arm Limited or its affiliates.
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -49,3 +49,6 @@ void test_avgpooling_int16_arm_avgpool_s16(void) { avgpooling_int16_arm_avgpool_
 void test_avgpooling_1_int16_arm_avgpool_s16(void) { avgpooling_int16_1_arm_avgpool_s16(); }
 void test_avgpooling_2_int16_arm_avgpool_s16(void) { avgpooling_int16_2_arm_avgpool_s16(); }
 void test_avgpooling_3_int16_arm_avgpool_s16(void) { avgpooling_int16_3_arm_avgpool_s16(); }
+
+void test_buffer_size_mve_arm_avgpool_s16(void) { buffer_size_mve_arm_avgpool_s16(); }
+void test_buffer_size_dsp_arm_avgpool_s16(void) { buffer_size_dsp_arm_avgpool_s16(); }

--- a/Tests/UnitTest/TestCases/test_arm_avgpool_s16/test_arm_avgpool_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_avgpool_s16/test_arm_avgpool_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -208,4 +208,26 @@ void avgpooling_int16_3_arm_avgpool_s16(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, avgpooling_int16_3_output_ref, AVGPOOLING_INT16_3_DST_SIZE));
+}
+
+void buffer_size_mve_arm_avgpool_s16(void)
+{
+#if defined(ARM_MATH_MVEI)
+    const int32_t buf_size = arm_avgpool_s16_get_buffer_size(AVGPOOLING_INT16_3_OUTPUT_W, AVGPOOLING_INT16_3_IN_CH);
+    const int32_t mve_buf_size =
+        arm_avgpool_s16_get_buffer_size_mve(AVGPOOLING_INT16_3_OUTPUT_W, AVGPOOLING_INT16_3_IN_CH);
+
+    TEST_ASSERT_EQUAL(buf_size, mve_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_avgpool_s16(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    const int32_t buf_size = arm_avgpool_s16_get_buffer_size(AVGPOOLING_INT16_3_OUTPUT_W, AVGPOOLING_INT16_3_IN_CH);
+    const int32_t dsp_buf_size =
+        arm_avgpool_s16_get_buffer_size_dsp(AVGPOOLING_INT16_3_OUTPUT_W, AVGPOOLING_INT16_3_IN_CH);
+
+    TEST_ASSERT_EQUAL(buf_size, dsp_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_avgpool_s8/Unity/unity_test_arm_avgpool_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_avgpool_s8/Unity/unity_test_arm_avgpool_s8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright 2010-2021, 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -55,3 +55,7 @@ void test_avgpooling_3_arm_avgpool_s8(void) { avgpooling_3_arm_avgpool_s8(); }
 void test_avgpooling_4_arm_avgpool_s8(void) { avgpooling_4_arm_avgpool_s8(); }
 
 void test_avgpooling_5_arm_avgpool_s8(void) { avgpooling_5_arm_avgpool_s8(); }
+
+void test_buffer_size_mve_arm_avgpool_s8(void) { buffer_size_mve_arm_avgpool_s8(); }
+
+void test_buffer_size_dsp_arm_avgpool_s8(void) { buffer_size_dsp_arm_avgpool_s8(); }

--- a/Tests/UnitTest/TestCases/test_arm_avgpool_s8/test_arm_avgpool_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_avgpool_s8/test_arm_avgpool_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -302,4 +302,24 @@ void avgpooling_5_arm_avgpool_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, avgpooling_5_output_ref, AVGPOOLING_5_DST_SIZE));
+}
+
+void buffer_size_mve_arm_avgpool_s8(void)
+{
+#if defined(ARM_MATH_MVEI)
+    const int32_t buf_size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_5_OUTPUT_W, AVGPOOLING_5_IN_CH);
+    const int32_t mve_buf_size = arm_avgpool_s8_get_buffer_size_mve(AVGPOOLING_5_OUTPUT_W, AVGPOOLING_5_IN_CH);
+
+    TEST_ASSERT_EQUAL(buf_size, mve_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_avgpool_s8(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    const int32_t buf_size = arm_avgpool_s8_get_buffer_size(AVGPOOLING_5_OUTPUT_W, AVGPOOLING_5_IN_CH);
+    const int32_t dsp_buf_size = arm_avgpool_s8_get_buffer_size_dsp(AVGPOOLING_5_OUTPUT_W, AVGPOOLING_5_IN_CH);
+
+    TEST_ASSERT_EQUAL(buf_size, dsp_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/Unity/unity_test_arm_convolve_1x1_s8_fast.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/Unity/unity_test_arm_convolve_1x1_s8_fast.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2020, 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -49,3 +49,6 @@ void test_kernel1x1_stride_x_arm_convolve_1x1_s8(void) { kernel1x1_stride_x_arm_
 void test_kernel1x1_stride_x_y_arm_convolve_1x1_s8(void) { kernel1x1_stride_x_y_arm_convolve_1x1_s8(); }
 void test_kernel1x1_stride_x_y_1_arm_convolve_1x1_s8(void) { kernel1x1_stride_x_y_1_arm_convolve_1x1_s8(); }
 void test_kernel1x1_stride_x_y_2_arm_convolve_1x1_s8(void) { kernel1x1_stride_x_y_2_arm_convolve_1x1_s8(); }
+void test_buffer_size_arm_convolve_1x1_s8_fast(void) { buffer_size_arm_convolve_1x1_s8_fast(); }
+void test_buffer_size_mve_arm_convolve_1x1_s8_fast(void) { buffer_size_mve_arm_convolve_1x1_s8_fast(); }
+void test_buffer_size_dsp_arm_convolve_1x1_s8_fast(void) { buffer_size_dsp_arm_convolve_1x1_s8_fast(); }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/test_arm_convolve_1x1_s8_fast.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/test_arm_convolve_1x1_s8_fast.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -410,4 +410,118 @@ void kernel1x1_stride_x_y_2_arm_convolve_1x1_s8(void)
     TEST_ASSERT_EQUAL(expected, result);
 
     TEST_ASSERT_TRUE(validate(output, kernel1x1_stride_x_y_2_output_ref, KERNEL1X1_STRIDE_X_Y_2_DST_SIZE));
+}
+
+void buffer_size_arm_convolve_1x1_s8_fast(void)
+{
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = KERNEL1X1_STRIDE_X_Y_2_INPUT_BATCHES;
+    input_dims.w = KERNEL1X1_STRIDE_X_Y_2_INPUT_W;
+    input_dims.h = KERNEL1X1_STRIDE_X_Y_2_INPUT_H;
+    input_dims.c = KERNEL1X1_STRIDE_X_Y_2_IN_CH;
+    filter_dims.w = KERNEL1X1_STRIDE_X_Y_2_FILTER_X;
+    filter_dims.h = KERNEL1X1_STRIDE_X_Y_2_FILTER_Y;
+    output_dims.w = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_W;
+    output_dims.h = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_H;
+    output_dims.c = KERNEL1X1_STRIDE_X_Y_2_OUT_CH;
+
+    conv_params.padding.w = KERNEL1X1_STRIDE_X_Y_2_PAD_X;
+    conv_params.padding.h = KERNEL1X1_STRIDE_X_Y_2_PAD_Y;
+    conv_params.stride.w = KERNEL1X1_STRIDE_X_Y_2_STRIDE_X;
+    conv_params.stride.h = KERNEL1X1_STRIDE_X_Y_2_STRIDE_Y;
+    conv_params.dilation.w = KERNEL1X1_STRIDE_X_Y_2_DILATION_X;
+    conv_params.dilation.h = KERNEL1X1_STRIDE_X_Y_2_DILATION_Y;
+
+    conv_params.input_offset = KERNEL1X1_STRIDE_X_Y_2_INPUT_OFFSET;
+    conv_params.output_offset = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_OFFSET;
+    conv_params.activation.min = KERNEL1X1_STRIDE_X_Y_2_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = KERNEL1X1_STRIDE_X_Y_2_OUT_ACTIVATION_MAX;
+
+    const int32_t buf_size = arm_convolve_1x1_s8_fast_get_buffer_size(&input_dims);
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, buf_size);
+}
+
+void buffer_size_mve_arm_convolve_1x1_s8_fast(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = KERNEL1X1_STRIDE_X_Y_2_INPUT_BATCHES;
+    input_dims.w = KERNEL1X1_STRIDE_X_Y_2_INPUT_W;
+    input_dims.h = KERNEL1X1_STRIDE_X_Y_2_INPUT_H;
+    input_dims.c = KERNEL1X1_STRIDE_X_Y_2_IN_CH;
+    filter_dims.w = KERNEL1X1_STRIDE_X_Y_2_FILTER_X;
+    filter_dims.h = KERNEL1X1_STRIDE_X_Y_2_FILTER_Y;
+    output_dims.w = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_W;
+    output_dims.h = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_H;
+    output_dims.c = KERNEL1X1_STRIDE_X_Y_2_OUT_CH;
+
+    conv_params.padding.w = KERNEL1X1_STRIDE_X_Y_2_PAD_X;
+    conv_params.padding.h = KERNEL1X1_STRIDE_X_Y_2_PAD_Y;
+    conv_params.stride.w = KERNEL1X1_STRIDE_X_Y_2_STRIDE_X;
+    conv_params.stride.h = KERNEL1X1_STRIDE_X_Y_2_STRIDE_Y;
+    conv_params.dilation.w = KERNEL1X1_STRIDE_X_Y_2_DILATION_X;
+    conv_params.dilation.h = KERNEL1X1_STRIDE_X_Y_2_DILATION_Y;
+
+    conv_params.input_offset = KERNEL1X1_STRIDE_X_Y_2_INPUT_OFFSET;
+    conv_params.output_offset = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_OFFSET;
+    conv_params.activation.min = KERNEL1X1_STRIDE_X_Y_2_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = KERNEL1X1_STRIDE_X_Y_2_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_convolve_1x1_s8_fast(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = KERNEL1X1_STRIDE_X_Y_2_INPUT_BATCHES;
+    input_dims.w = KERNEL1X1_STRIDE_X_Y_2_INPUT_W;
+    input_dims.h = KERNEL1X1_STRIDE_X_Y_2_INPUT_H;
+    input_dims.c = KERNEL1X1_STRIDE_X_Y_2_IN_CH;
+    filter_dims.w = KERNEL1X1_STRIDE_X_Y_2_FILTER_X;
+    filter_dims.h = KERNEL1X1_STRIDE_X_Y_2_FILTER_Y;
+    output_dims.w = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_W;
+    output_dims.h = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_H;
+    output_dims.c = KERNEL1X1_STRIDE_X_Y_2_OUT_CH;
+
+    conv_params.padding.w = KERNEL1X1_STRIDE_X_Y_2_PAD_X;
+    conv_params.padding.h = KERNEL1X1_STRIDE_X_Y_2_PAD_Y;
+    conv_params.stride.w = KERNEL1X1_STRIDE_X_Y_2_STRIDE_X;
+    conv_params.stride.h = KERNEL1X1_STRIDE_X_Y_2_STRIDE_Y;
+    conv_params.dilation.w = KERNEL1X1_STRIDE_X_Y_2_DILATION_X;
+    conv_params.dilation.h = KERNEL1X1_STRIDE_X_Y_2_DILATION_Y;
+
+    conv_params.input_offset = KERNEL1X1_STRIDE_X_Y_2_INPUT_OFFSET;
+    conv_params.output_offset = KERNEL1X1_STRIDE_X_Y_2_OUTPUT_OFFSET;
+    conv_params.activation.min = KERNEL1X1_STRIDE_X_Y_2_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = KERNEL1X1_STRIDE_X_Y_2_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/Unity/unity_test_arm_convolve_fast_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/Unity/unity_test_arm_convolve_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2021, 2023 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -46,3 +46,6 @@ void tearDown(void) {}
 
 void test_int16xint8_arm_convolve_fast_s16(void) { int16xint8_arm_convolve_fast_s16(); }
 void test_requantize_s64_arm_convolve_fast_s16(void) { requantize_s64_arm_convolve_fast_s16(); }
+void test_buffer_size_arm_convolve_fast_s16(void) { buffer_size_arm_convolve_fast_s16(); }
+void test_buffer_size_mve_arm_convolve_fast_s16(void) { buffer_size_mve_arm_convolve_fast_s16(); }
+void test_buffer_size_dsp_arm_convolve_fast_s16(void) { buffer_size_dsp_arm_convolve_fast_s16(); }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/test_arm_convolve_fast_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_fast_s16/test_arm_convolve_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> All rights
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com> All rights
  * reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -210,5 +210,119 @@ void requantize_s64_arm_convolve_fast_s16(void)
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
 #else
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_ARG_ERROR, result);
+#endif
+}
+
+void buffer_size_arm_convolve_fast_s16(void)
+{
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = REQUANTIZE_S64_INPUT_BATCHES;
+    input_dims.w = REQUANTIZE_S64_INPUT_W;
+    input_dims.h = REQUANTIZE_S64_INPUT_H;
+    input_dims.c = REQUANTIZE_S64_IN_CH;
+    filter_dims.w = REQUANTIZE_S64_FILTER_X;
+    filter_dims.h = REQUANTIZE_S64_FILTER_Y;
+    output_dims.w = REQUANTIZE_S64_OUTPUT_W;
+    output_dims.h = REQUANTIZE_S64_OUTPUT_H;
+    output_dims.c = REQUANTIZE_S64_OUT_CH;
+
+    conv_params.padding.w = REQUANTIZE_S64_PAD_X;
+    conv_params.padding.h = REQUANTIZE_S64_PAD_Y;
+    conv_params.stride.w = REQUANTIZE_S64_STRIDE_X;
+    conv_params.stride.h = REQUANTIZE_S64_STRIDE_Y;
+    conv_params.dilation.w = REQUANTIZE_S64_DILATION_X;
+    conv_params.dilation.h = REQUANTIZE_S64_DILATION_Y;
+
+    conv_params.input_offset = REQUANTIZE_S64_INPUT_OFFSET;
+    conv_params.output_offset = REQUANTIZE_S64_OUTPUT_OFFSET;
+    conv_params.activation.min = REQUANTIZE_S64_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = REQUANTIZE_S64_OUT_ACTIVATION_MAX;
+
+    const int32_t buf_size = arm_convolve_fast_s16_get_buffer_size(&input_dims, &filter_dims);
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, buf_size);
+}
+
+void buffer_size_mve_arm_convolve_fast_s16(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = REQUANTIZE_S64_INPUT_BATCHES;
+    input_dims.w = REQUANTIZE_S64_INPUT_W;
+    input_dims.h = REQUANTIZE_S64_INPUT_H;
+    input_dims.c = REQUANTIZE_S64_IN_CH;
+    filter_dims.w = REQUANTIZE_S64_FILTER_X;
+    filter_dims.h = REQUANTIZE_S64_FILTER_Y;
+    output_dims.w = REQUANTIZE_S64_OUTPUT_W;
+    output_dims.h = REQUANTIZE_S64_OUTPUT_H;
+    output_dims.c = REQUANTIZE_S64_OUT_CH;
+
+    conv_params.padding.w = REQUANTIZE_S64_PAD_X;
+    conv_params.padding.h = REQUANTIZE_S64_PAD_Y;
+    conv_params.stride.w = REQUANTIZE_S64_STRIDE_X;
+    conv_params.stride.h = REQUANTIZE_S64_STRIDE_Y;
+    conv_params.dilation.w = REQUANTIZE_S64_DILATION_X;
+    conv_params.dilation.h = REQUANTIZE_S64_DILATION_Y;
+
+    conv_params.input_offset = REQUANTIZE_S64_INPUT_OFFSET;
+    conv_params.output_offset = REQUANTIZE_S64_OUTPUT_OFFSET;
+    conv_params.activation.min = REQUANTIZE_S64_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = REQUANTIZE_S64_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_convolve_fast_s16(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = REQUANTIZE_S64_INPUT_BATCHES;
+    input_dims.w = REQUANTIZE_S64_INPUT_W;
+    input_dims.h = REQUANTIZE_S64_INPUT_H;
+    input_dims.c = REQUANTIZE_S64_IN_CH;
+    filter_dims.w = REQUANTIZE_S64_FILTER_X;
+    filter_dims.h = REQUANTIZE_S64_FILTER_Y;
+    output_dims.w = REQUANTIZE_S64_OUTPUT_W;
+    output_dims.h = REQUANTIZE_S64_OUTPUT_H;
+    output_dims.c = REQUANTIZE_S64_OUT_CH;
+
+    conv_params.padding.w = REQUANTIZE_S64_PAD_X;
+    conv_params.padding.h = REQUANTIZE_S64_PAD_Y;
+    conv_params.stride.w = REQUANTIZE_S64_STRIDE_X;
+    conv_params.stride.h = REQUANTIZE_S64_STRIDE_Y;
+    conv_params.dilation.w = REQUANTIZE_S64_DILATION_X;
+    conv_params.dilation.h = REQUANTIZE_S64_DILATION_Y;
+
+    conv_params.input_offset = REQUANTIZE_S64_INPUT_OFFSET;
+    conv_params.output_offset = REQUANTIZE_S64_OUTPUT_OFFSET;
+    conv_params.activation.min = REQUANTIZE_S64_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = REQUANTIZE_S64_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
 #endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_s16/Unity/unity_test_arm_convolve_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_s16/Unity/unity_test_arm_convolve_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (C) 2010-2023 Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -49,3 +49,6 @@ void test_requantize_s64_arm_convolve_s16(void) { requantize_s64_arm_convolve_s1
 void test_int16xint8_dilation_1_arm_convolve_s16(void) { int16xint8_dilation_1_arm_convolve_s16(); }
 void test_int16xint8_dilation_2_arm_convolve_s16(void) { int16xint8_dilation_2_arm_convolve_s16(); }
 void test_int16xint8_dilation_3_arm_convolve_s16(void) { int16xint8_dilation_3_arm_convolve_s16(); }
+void test_buffer_size_arm_convolve_s16(void) { buffer_size_arm_convolve_s16(); }
+void test_buffer_size_mve_arm_convolve_s16(void) { buffer_size_mve_arm_convolve_s16(); }
+void test_buffer_size_dsp_arm_convolve_s16(void) { buffer_size_dsp_arm_convolve_s16(); }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_s16/test_arm_convolve_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_s16/test_arm_convolve_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com> All rights
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com> All rights
  * reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -473,4 +473,118 @@ void int16xint8_dilation_3_arm_convolve_s16(void)
     }
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_SUCCESS, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+}
+
+void buffer_size_arm_convolve_s16(void)
+{
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = INT16XINT8_DILATION_3_INPUT_BATCHES;
+    input_dims.w = INT16XINT8_DILATION_3_INPUT_W;
+    input_dims.h = INT16XINT8_DILATION_3_INPUT_H;
+    input_dims.c = INT16XINT8_DILATION_3_IN_CH;
+    filter_dims.w = INT16XINT8_DILATION_3_FILTER_X;
+    filter_dims.h = INT16XINT8_DILATION_3_FILTER_Y;
+    output_dims.w = INT16XINT8_DILATION_3_OUTPUT_W;
+    output_dims.h = INT16XINT8_DILATION_3_OUTPUT_H;
+    output_dims.c = INT16XINT8_DILATION_3_OUT_CH;
+
+    conv_params.padding.w = INT16XINT8_DILATION_3_PAD_X;
+    conv_params.padding.h = INT16XINT8_DILATION_3_PAD_Y;
+    conv_params.stride.w = INT16XINT8_DILATION_3_STRIDE_X;
+    conv_params.stride.h = INT16XINT8_DILATION_3_STRIDE_Y;
+    conv_params.dilation.w = INT16XINT8_DILATION_3_DILATION_X;
+    conv_params.dilation.h = INT16XINT8_DILATION_3_DILATION_Y;
+
+    conv_params.input_offset = INT16XINT8_DILATION_3_INPUT_OFFSET;
+    conv_params.output_offset = INT16XINT8_DILATION_3_OUTPUT_OFFSET;
+    conv_params.activation.min = INT16XINT8_DILATION_3_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = INT16XINT8_DILATION_3_OUT_ACTIVATION_MAX;
+
+    const int32_t buf_size = arm_convolve_s16_get_buffer_size(&input_dims, &filter_dims);
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, buf_size);
+}
+
+void buffer_size_mve_arm_convolve_s16(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = INT16XINT8_DILATION_3_INPUT_BATCHES;
+    input_dims.w = INT16XINT8_DILATION_3_INPUT_W;
+    input_dims.h = INT16XINT8_DILATION_3_INPUT_H;
+    input_dims.c = INT16XINT8_DILATION_3_IN_CH;
+    filter_dims.w = INT16XINT8_DILATION_3_FILTER_X;
+    filter_dims.h = INT16XINT8_DILATION_3_FILTER_Y;
+    output_dims.w = INT16XINT8_DILATION_3_OUTPUT_W;
+    output_dims.h = INT16XINT8_DILATION_3_OUTPUT_H;
+    output_dims.c = INT16XINT8_DILATION_3_OUT_CH;
+
+    conv_params.padding.w = INT16XINT8_DILATION_3_PAD_X;
+    conv_params.padding.h = INT16XINT8_DILATION_3_PAD_Y;
+    conv_params.stride.w = INT16XINT8_DILATION_3_STRIDE_X;
+    conv_params.stride.h = INT16XINT8_DILATION_3_STRIDE_Y;
+    conv_params.dilation.w = INT16XINT8_DILATION_3_DILATION_X;
+    conv_params.dilation.h = INT16XINT8_DILATION_3_DILATION_Y;
+
+    conv_params.input_offset = INT16XINT8_DILATION_3_INPUT_OFFSET;
+    conv_params.output_offset = INT16XINT8_DILATION_3_OUTPUT_OFFSET;
+    conv_params.activation.min = INT16XINT8_DILATION_3_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = INT16XINT8_DILATION_3_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_convolve_s16(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = INT16XINT8_DILATION_3_INPUT_BATCHES;
+    input_dims.w = INT16XINT8_DILATION_3_INPUT_W;
+    input_dims.h = INT16XINT8_DILATION_3_INPUT_H;
+    input_dims.c = INT16XINT8_DILATION_3_IN_CH;
+    filter_dims.w = INT16XINT8_DILATION_3_FILTER_X;
+    filter_dims.h = INT16XINT8_DILATION_3_FILTER_Y;
+    output_dims.w = INT16XINT8_DILATION_3_OUTPUT_W;
+    output_dims.h = INT16XINT8_DILATION_3_OUTPUT_H;
+    output_dims.c = INT16XINT8_DILATION_3_OUT_CH;
+
+    conv_params.padding.w = INT16XINT8_DILATION_3_PAD_X;
+    conv_params.padding.h = INT16XINT8_DILATION_3_PAD_Y;
+    conv_params.stride.w = INT16XINT8_DILATION_3_STRIDE_X;
+    conv_params.stride.h = INT16XINT8_DILATION_3_STRIDE_Y;
+    conv_params.dilation.w = INT16XINT8_DILATION_3_DILATION_X;
+    conv_params.dilation.h = INT16XINT8_DILATION_3_DILATION_Y;
+
+    conv_params.input_offset = INT16XINT8_DILATION_3_INPUT_OFFSET;
+    conv_params.output_offset = INT16XINT8_DILATION_3_OUTPUT_OFFSET;
+    conv_params.activation.min = INT16XINT8_DILATION_3_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = INT16XINT8_DILATION_3_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_convolve_wrapper_s16_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_s8/Unity/unity_test_arm_convolve_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_s8/Unity/unity_test_arm_convolve_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -75,3 +75,9 @@ void test_conv_3x2_dilation_arm_convolve_s8(void) { conv_3x2_dilation_arm_convol
 void test_conv_3x3_dilation_5x5_input_arm_convolve_s8(void) { conv_3x3_dilation_5x5_input_arm_convolve_s8(); }
 
 void test_conv_2x2_dilation_5x5_input_arm_convolve_s8(void) { conv_2x2_dilation_5x5_input_arm_convolve_s8(); }
+
+void test_buffer_size_arm_convolve_s8(void) { buffer_size_arm_convolve_s8(); }
+
+void test_buffer_size_mve_arm_convolve_s8(void) { buffer_size_mve_arm_convolve_s8(); }
+
+void test_buffer_size_dsp_arm_convolve_s8(void) { buffer_size_dsp_arm_convolve_s8(); }

--- a/Tests/UnitTest/TestCases/test_arm_convolve_s8/test_arm_convolve_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_s8/test_arm_convolve_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -1480,4 +1480,118 @@ void conv_5_arm_convolve_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
+}
+
+void buffer_size_arm_convolve_s8(void)
+{
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = CONV_5_INPUT_BATCHES;
+    input_dims.w = CONV_5_INPUT_W;
+    input_dims.h = CONV_5_INPUT_H;
+    input_dims.c = CONV_5_IN_CH;
+    filter_dims.w = CONV_5_FILTER_X;
+    filter_dims.h = CONV_5_FILTER_Y;
+    output_dims.w = CONV_5_OUTPUT_W;
+    output_dims.h = CONV_5_OUTPUT_H;
+    output_dims.c = CONV_5_OUT_CH;
+
+    conv_params.padding.w = CONV_5_PAD_X;
+    conv_params.padding.h = CONV_5_PAD_Y;
+    conv_params.stride.w = CONV_5_STRIDE_X;
+    conv_params.stride.h = CONV_5_STRIDE_Y;
+    conv_params.dilation.w = CONV_5_DILATION_X;
+    conv_params.dilation.h = CONV_5_DILATION_Y;
+
+    conv_params.input_offset = CONV_5_INPUT_OFFSET;
+    conv_params.output_offset = CONV_5_OUTPUT_OFFSET;
+    conv_params.activation.min = CONV_5_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = CONV_5_OUT_ACTIVATION_MAX;
+
+    const int32_t buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, buf_size);
+}
+
+void buffer_size_mve_arm_convolve_s8(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = CONV_5_INPUT_BATCHES;
+    input_dims.w = CONV_5_INPUT_W;
+    input_dims.h = CONV_5_INPUT_H;
+    input_dims.c = CONV_5_IN_CH;
+    filter_dims.w = CONV_5_FILTER_X;
+    filter_dims.h = CONV_5_FILTER_Y;
+    output_dims.w = CONV_5_OUTPUT_W;
+    output_dims.h = CONV_5_OUTPUT_H;
+    output_dims.c = CONV_5_OUT_CH;
+
+    conv_params.padding.w = CONV_5_PAD_X;
+    conv_params.padding.h = CONV_5_PAD_Y;
+    conv_params.stride.w = CONV_5_STRIDE_X;
+    conv_params.stride.h = CONV_5_STRIDE_Y;
+    conv_params.dilation.w = CONV_5_DILATION_X;
+    conv_params.dilation.h = CONV_5_DILATION_Y;
+
+    conv_params.input_offset = CONV_5_INPUT_OFFSET;
+    conv_params.output_offset = CONV_5_OUTPUT_OFFSET;
+    conv_params.activation.min = CONV_5_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = CONV_5_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_convolve_s8(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = CONV_5_INPUT_BATCHES;
+    input_dims.w = CONV_5_INPUT_W;
+    input_dims.h = CONV_5_INPUT_H;
+    input_dims.c = CONV_5_IN_CH;
+    filter_dims.w = CONV_5_FILTER_X;
+    filter_dims.h = CONV_5_FILTER_Y;
+    output_dims.w = CONV_5_OUTPUT_W;
+    output_dims.h = CONV_5_OUTPUT_H;
+    output_dims.c = CONV_5_OUT_CH;
+
+    conv_params.padding.w = CONV_5_PAD_X;
+    conv_params.padding.h = CONV_5_PAD_Y;
+    conv_params.stride.w = CONV_5_STRIDE_X;
+    conv_params.stride.h = CONV_5_STRIDE_Y;
+    conv_params.dilation.w = CONV_5_DILATION_X;
+    conv_params.dilation.h = CONV_5_DILATION_Y;
+
+    conv_params.input_offset = CONV_5_INPUT_OFFSET;
+    conv_params.output_offset = CONV_5_OUTPUT_OFFSET;
+    conv_params.activation.min = CONV_5_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = CONV_5_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_convolve_wrapper_s8_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/Unity/unity_test_arm_depthwise_conv_3x3_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/Unity/unity_test_arm_depthwise_conv_3x3_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2020, 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -54,3 +54,7 @@ void test_depthwise_kernel_3x3_arm_depthwise_conv_3x3_null_bias_s8(void)
 }
 
 void test_stride2pad1_arm_depthwise_conv_3x3_s8(void) { stride2pad1_arm_depthwise_conv_3x3_s8(); }
+
+void test_buffer_size_mve_arm_depthwise_conv_3x3_s8(void) { buffer_size_mve_arm_depthwise_conv_3x3_s8(); }
+
+void test_buffer_size_dsp_arm_depthwise_conv_3x3_s8(void) { buffer_size_dsp_arm_depthwise_conv_3x3_s8(); }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/test_arm_depthwise_conv_3x3_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_3x3_s8/test_arm_depthwise_conv_3x3_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -431,4 +431,84 @@ void stride2pad1_arm_depthwise_conv_3x3_s8(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, stride2pad1_output_ref, output_ref_size));
+}
+
+void buffer_size_mve_arm_depthwise_conv_3x3_s8(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_W;
+    input_dims.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_H;
+    input_dims.c = DEPTHWISE_KERNEL_3X3_NULL_BIAS_IN_CH;
+    filter_dims.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_FILTER_X;
+    filter_dims.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_FILTER_Y;
+    output_dims.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUTPUT_W;
+    output_dims.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUTPUT_H;
+    output_dims.c = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_PAD_X;
+    conv_params.padding.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_DILATION_Y;
+    conv_params.ch_mult = DEPTHWISE_KERNEL_3X3_NULL_BIAS_CH_MULT;
+    conv_params.input_offset = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_depthwise_conv_3x3_s8(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_W;
+    input_dims.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_H;
+    input_dims.c = DEPTHWISE_KERNEL_3X3_NULL_BIAS_IN_CH;
+    filter_dims.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_FILTER_X;
+    filter_dims.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_FILTER_Y;
+    output_dims.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUTPUT_W;
+    output_dims.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUTPUT_H;
+    output_dims.c = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_PAD_X;
+    conv_params.padding.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_KERNEL_3X3_NULL_BIAS_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_KERNEL_3X3_NULL_BIAS_DILATION_Y;
+
+    conv_params.ch_mult = DEPTHWISE_KERNEL_3X3_NULL_BIAS_CH_MULT;
+
+    conv_params.input_offset = DEPTHWISE_KERNEL_3X3_NULL_BIAS_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_KERNEL_3X3_NULL_BIAS_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_fast_s16/Unity/unity_test_arm_depthwise_conv_fast_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_fast_s16/Unity/unity_test_arm_depthwise_conv_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Arm Limited or its affiliates.
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -77,3 +77,8 @@ void test_dw_int16xint8_fast_multiple_batches_uneven_buffers_null_bias_arm_depth
 {
     dw_int16xint8_fast_multiple_batches_uneven_buffers_null_bias_arm_depthwise_conv_fast_s16();
 }
+void test_buffer_size_arm_depthwise_conv_fast_s16(void) { buffer_size_arm_depthwise_conv_fast_s16(); }
+
+void test_buffer_size_mve_arm_depthwise_conv_fast_s16(void) { buffer_size_mve_arm_depthwise_conv_fast_s16(); }
+
+void test_buffer_size_dsp_arm_depthwise_conv_fast_s16(void) { buffer_size_dsp_arm_depthwise_conv_fast_s16(); }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_fast_s16/test_arm_depthwise_conv_fast_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_fast_s16/test_arm_depthwise_conv_fast_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -901,4 +901,120 @@ void dw_int16xint8_fast_multiple_batches_uneven_buffers_null_bias_arm_depthwise_
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate_s16(output, output_ref, output_ref_size));
+}
+
+void buffer_size_arm_depthwise_conv_fast_s16(void)
+{
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_BATCHES;
+    input_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_W;
+    input_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_H;
+    input_dims.c = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_IN_CH;
+    filter_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_FILTER_X;
+    filter_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_FILTER_Y;
+    output_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_W;
+    output_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_H;
+    output_dims.c = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_CH;
+
+    conv_params.padding.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_PAD_X;
+    conv_params.padding.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_PAD_Y;
+    conv_params.stride.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_STRIDE_X;
+    conv_params.stride.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_STRIDE_Y;
+    conv_params.dilation.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_DILATION_X;
+    conv_params.dilation.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_DILATION_Y;
+    conv_params.ch_mult = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_CH_MULT;
+    conv_params.input_offset = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_OFFSET;
+    conv_params.output_offset = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_OFFSET;
+    conv_params.activation.min = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_ACTIVATION_MAX;
+
+    const int32_t buf_size = arm_depthwise_conv_fast_s16_get_buffer_size(&input_dims, &filter_dims);
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, buf_size);
+}
+
+void buffer_size_mve_arm_depthwise_conv_fast_s16(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_BATCHES;
+    input_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_W;
+    input_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_H;
+    input_dims.c = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_IN_CH;
+    filter_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_FILTER_X;
+    filter_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_FILTER_Y;
+    output_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_W;
+    output_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_H;
+    output_dims.c = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_CH;
+
+    conv_params.padding.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_PAD_X;
+    conv_params.padding.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_PAD_Y;
+    conv_params.stride.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_STRIDE_X;
+    conv_params.stride.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_STRIDE_Y;
+    conv_params.dilation.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_DILATION_X;
+    conv_params.dilation.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_DILATION_Y;
+    conv_params.ch_mult = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_CH_MULT;
+    conv_params.input_offset = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_OFFSET;
+    conv_params.output_offset = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_OFFSET;
+    conv_params.activation.min = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_depthwise_conv_fast_s16(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_BATCHES;
+    input_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_W;
+    input_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_H;
+    input_dims.c = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_IN_CH;
+    filter_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_FILTER_X;
+    filter_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_FILTER_Y;
+    output_dims.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_W;
+    output_dims.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_H;
+    output_dims.c = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_CH;
+
+    conv_params.padding.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_PAD_X;
+    conv_params.padding.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_PAD_Y;
+    conv_params.stride.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_STRIDE_X;
+    conv_params.stride.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_STRIDE_Y;
+    conv_params.dilation.w = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_DILATION_X;
+    conv_params.dilation.h = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_DILATION_Y;
+
+    conv_params.ch_mult = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_CH_MULT;
+
+    conv_params.input_offset = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_INPUT_OFFSET;
+    conv_params.output_offset = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUTPUT_OFFSET;
+    conv_params.activation.min = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DW_INT16XINT8_FAST_MULTIPLE_BATCHES_UNEVEN_BUFFERS_NULL_BIAS_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/Unity/unity_test_arm_depthwise_conv_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/Unity/unity_test_arm_depthwise_conv_s16.c
@@ -48,3 +48,5 @@ void test_dw_int16xint8_arm_depthwise_conv_s16(void) { dw_int16xint8_arm_depthwi
 void test_dw_int16xint8_dilation_arm_depthwise_conv_s16(void) { dw_int16xint8_dilation_arm_depthwise_conv_s16(); }
 void test_dw_int16xint8_mult4_arm_depthwise_conv_s16(void) { dw_int16xint8_mult4_arm_depthwise_conv_s16(); }
 void test_arm_depthwise_conv_wrapper_s16_buffer(void) { arm_depthwise_conv_wrapper_s16_buffer(); }
+void test_buffer_size_mve_arm_depthwise_conv_s16(void) { buffer_size_mve_arm_depthwise_conv_s16(); }
+void test_buffer_size_dsp_arm_depthwise_conv_s16(void) { buffer_size_dsp_arm_depthwise_conv_s16(); }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/Unity/unity_test_arm_depthwise_conv_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/Unity/unity_test_arm_depthwise_conv_s16.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2023 Arm Limited or its affiliates.
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/test_arm_depthwise_conv_s16.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s16/test_arm_depthwise_conv_s16.c
@@ -360,3 +360,83 @@ void arm_depthwise_conv_wrapper_s16_buffer(void)
     TEST_ASSERT_TRUE(size == 0);
 #endif
 }
+
+void buffer_size_mve_arm_depthwise_conv_s16(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DW_INT16XINT8_MULT4_INPUT_BATCHES;
+    input_dims.w = DW_INT16XINT8_MULT4_INPUT_W;
+    input_dims.h = DW_INT16XINT8_MULT4_INPUT_H;
+    input_dims.c = DW_INT16XINT8_MULT4_IN_CH;
+    filter_dims.w = DW_INT16XINT8_MULT4_FILTER_X;
+    filter_dims.h = DW_INT16XINT8_MULT4_FILTER_Y;
+    output_dims.w = DW_INT16XINT8_MULT4_OUTPUT_W;
+    output_dims.h = DW_INT16XINT8_MULT4_OUTPUT_H;
+    output_dims.c = DW_INT16XINT8_MULT4_OUT_CH;
+
+    conv_params.padding.w = DW_INT16XINT8_MULT4_PAD_X;
+    conv_params.padding.h = DW_INT16XINT8_MULT4_PAD_Y;
+    conv_params.stride.w = DW_INT16XINT8_MULT4_STRIDE_X;
+    conv_params.stride.h = DW_INT16XINT8_MULT4_STRIDE_Y;
+    conv_params.dilation.w = DW_INT16XINT8_MULT4_DILATION_X;
+    conv_params.dilation.h = DW_INT16XINT8_MULT4_DILATION_Y;
+    conv_params.ch_mult = DW_INT16XINT8_MULT4_CH_MULT;
+    conv_params.input_offset = DW_INT16XINT8_MULT4_INPUT_OFFSET;
+    conv_params.output_offset = DW_INT16XINT8_MULT4_OUTPUT_OFFSET;
+    conv_params.activation.min = DW_INT16XINT8_MULT4_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DW_INT16XINT8_MULT4_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_depthwise_conv_s16(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DW_INT16XINT8_MULT4_INPUT_BATCHES;
+    input_dims.w = DW_INT16XINT8_MULT4_INPUT_W;
+    input_dims.h = DW_INT16XINT8_MULT4_INPUT_H;
+    input_dims.c = DW_INT16XINT8_MULT4_IN_CH;
+    filter_dims.w = DW_INT16XINT8_MULT4_FILTER_X;
+    filter_dims.h = DW_INT16XINT8_MULT4_FILTER_Y;
+    output_dims.w = DW_INT16XINT8_MULT4_OUTPUT_W;
+    output_dims.h = DW_INT16XINT8_MULT4_OUTPUT_H;
+    output_dims.c = DW_INT16XINT8_MULT4_OUT_CH;
+
+    conv_params.padding.w = DW_INT16XINT8_MULT4_PAD_X;
+    conv_params.padding.h = DW_INT16XINT8_MULT4_PAD_Y;
+    conv_params.stride.w = DW_INT16XINT8_MULT4_STRIDE_X;
+    conv_params.stride.h = DW_INT16XINT8_MULT4_STRIDE_Y;
+    conv_params.dilation.w = DW_INT16XINT8_MULT4_DILATION_X;
+    conv_params.dilation.h = DW_INT16XINT8_MULT4_DILATION_Y;
+
+    conv_params.ch_mult = DW_INT16XINT8_MULT4_CH_MULT;
+
+    conv_params.input_offset = DW_INT16XINT8_MULT4_INPUT_OFFSET;
+    conv_params.output_offset = DW_INT16XINT8_MULT4_OUTPUT_OFFSET;
+    conv_params.activation.min = DW_INT16XINT8_MULT4_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DW_INT16XINT8_MULT4_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s16_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
+}

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/Unity/unity_test_arm_depthwise_conv_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/Unity/unity_test_arm_depthwise_conv_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -51,3 +51,7 @@ void test_depthwise_mult_batches_arm_depthwise_conv_s8(void) { depthwise_mult_ba
 void test_depthwise_null_bias_1_arm_depthwise_conv_s8(void) { depthwise_null_bias_1_arm_depthwise_conv_s8(); }
 
 void test_depthwise_dilation_arm_depthwise_conv_s8(void) { depthwise_dilation_arm_depthwise_conv_s8(); }
+
+void test_buffer_size_mve_arm_depthwise_conv_s8(void) { buffer_size_mve_arm_depthwise_conv_s8(); }
+
+void test_buffer_size_dsp_arm_depthwise_conv_s8(void) { buffer_size_dsp_arm_depthwise_conv_s8(); }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/test_arm_depthwise_conv_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8/test_arm_depthwise_conv_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -401,4 +401,84 @@ void depthwise_dilation_arm_depthwise_conv_s8(void)
                                            output);
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, depthwise_dilation_output_ref, output_ref_size));
+}
+
+void buffer_size_mve_arm_depthwise_conv_s8(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_DILATION_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_DILATION_INPUT_W;
+    input_dims.h = DEPTHWISE_DILATION_INPUT_H;
+    input_dims.c = DEPTHWISE_DILATION_IN_CH;
+    filter_dims.w = DEPTHWISE_DILATION_FILTER_X;
+    filter_dims.h = DEPTHWISE_DILATION_FILTER_Y;
+    output_dims.w = DEPTHWISE_DILATION_OUTPUT_W;
+    output_dims.h = DEPTHWISE_DILATION_OUTPUT_H;
+    output_dims.c = DEPTHWISE_DILATION_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_DILATION_PAD_X;
+    conv_params.padding.h = DEPTHWISE_DILATION_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_DILATION_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_DILATION_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_DILATION_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_DILATION_DILATION_Y;
+    conv_params.ch_mult = DEPTHWISE_DILATION_CH_MULT;
+    conv_params.input_offset = DEPTHWISE_DILATION_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_DILATION_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_DILATION_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_DILATION_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_depthwise_conv_s8(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_DILATION_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_DILATION_INPUT_W;
+    input_dims.h = DEPTHWISE_DILATION_INPUT_H;
+    input_dims.c = DEPTHWISE_DILATION_IN_CH;
+    filter_dims.w = DEPTHWISE_DILATION_FILTER_X;
+    filter_dims.h = DEPTHWISE_DILATION_FILTER_Y;
+    output_dims.w = DEPTHWISE_DILATION_OUTPUT_W;
+    output_dims.h = DEPTHWISE_DILATION_OUTPUT_H;
+    output_dims.c = DEPTHWISE_DILATION_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_DILATION_PAD_X;
+    conv_params.padding.h = DEPTHWISE_DILATION_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_DILATION_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_DILATION_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_DILATION_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_DILATION_DILATION_Y;
+
+    conv_params.ch_mult = DEPTHWISE_DILATION_CH_MULT;
+
+    conv_params.input_offset = DEPTHWISE_DILATION_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_DILATION_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_DILATION_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_DILATION_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/Unity/unity_test_arm_depthwise_conv_s8_opt.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/Unity/unity_test_arm_depthwise_conv_s8_opt.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2020, 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates  <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -58,3 +58,9 @@ void test_depthwise_out_activation_arm_depthwise_conv_s8_opt(void)
 void test_depthwise_null_bias_0_arm_depthwise_conv_s8_opt(void) { depthwise_null_bias_0_arm_depthwise_conv_s8_opt(); }
 
 void test_depthwise_x_stride_arm_depthwise_conv_s8_opt(void) { depthwise_x_stride_arm_depthwise_conv_s8_opt(); }
+
+void test_buffer_size_arm_depthwise_conv_s8_opt(void) { buffer_size_arm_depthwise_conv_s8_opt(); }
+
+void test_buffer_size_mve_arm_depthwise_conv_s8_opt(void) { buffer_size_mve_arm_depthwise_conv_s8_opt(); }
+
+void test_buffer_size_dsp_arm_depthwise_conv_s8_opt(void) { buffer_size_dsp_arm_depthwise_conv_s8_opt(); }

--- a/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/test_arm_depthwise_conv_s8_opt.c
+++ b/Tests/UnitTest/TestCases/test_arm_depthwise_conv_s8_opt/test_arm_depthwise_conv_s8_opt.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -635,4 +635,120 @@ void depthwise_x_stride_arm_depthwise_conv_s8_opt(void)
     }
     TEST_ASSERT_EQUAL(expected, result);
     TEST_ASSERT_TRUE(validate(output, depthwise_x_stride_output_ref, DEPTHWISE_X_STRIDE_DST_SIZE));
+}
+
+void buffer_size_arm_depthwise_conv_s8_opt(void)
+{
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_X_STRIDE_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_X_STRIDE_INPUT_W;
+    input_dims.h = DEPTHWISE_X_STRIDE_INPUT_H;
+    input_dims.c = DEPTHWISE_X_STRIDE_IN_CH;
+    filter_dims.w = DEPTHWISE_X_STRIDE_FILTER_X;
+    filter_dims.h = DEPTHWISE_X_STRIDE_FILTER_Y;
+    output_dims.w = DEPTHWISE_X_STRIDE_OUTPUT_W;
+    output_dims.h = DEPTHWISE_X_STRIDE_OUTPUT_H;
+    output_dims.c = DEPTHWISE_X_STRIDE_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_X_STRIDE_PAD_X;
+    conv_params.padding.h = DEPTHWISE_X_STRIDE_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_X_STRIDE_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_X_STRIDE_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_X_STRIDE_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_X_STRIDE_DILATION_Y;
+    conv_params.ch_mult = DEPTHWISE_X_STRIDE_CH_MULT;
+    conv_params.input_offset = DEPTHWISE_X_STRIDE_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_X_STRIDE_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_X_STRIDE_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_X_STRIDE_OUT_ACTIVATION_MAX;
+
+    const int32_t buf_size = arm_depthwise_conv_s8_opt_get_buffer_size(&input_dims, &filter_dims);
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, buf_size);
+}
+
+void buffer_size_mve_arm_depthwise_conv_s8_opt(void)
+{
+#if defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_X_STRIDE_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_X_STRIDE_INPUT_W;
+    input_dims.h = DEPTHWISE_X_STRIDE_INPUT_H;
+    input_dims.c = DEPTHWISE_X_STRIDE_IN_CH;
+    filter_dims.w = DEPTHWISE_X_STRIDE_FILTER_X;
+    filter_dims.h = DEPTHWISE_X_STRIDE_FILTER_Y;
+    output_dims.w = DEPTHWISE_X_STRIDE_OUTPUT_W;
+    output_dims.h = DEPTHWISE_X_STRIDE_OUTPUT_H;
+    output_dims.c = DEPTHWISE_X_STRIDE_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_X_STRIDE_PAD_X;
+    conv_params.padding.h = DEPTHWISE_X_STRIDE_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_X_STRIDE_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_X_STRIDE_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_X_STRIDE_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_X_STRIDE_DILATION_Y;
+    conv_params.ch_mult = DEPTHWISE_X_STRIDE_CH_MULT;
+    conv_params.input_offset = DEPTHWISE_X_STRIDE_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_X_STRIDE_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_X_STRIDE_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_X_STRIDE_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t mve_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size_mve(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, mve_wrapper_buf_size);
+#endif
+}
+
+void buffer_size_dsp_arm_depthwise_conv_s8_opt(void)
+{
+#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_MVEI)
+    cmsis_nn_dw_conv_params conv_params;
+    cmsis_nn_dims input_dims;
+    cmsis_nn_dims filter_dims;
+    cmsis_nn_dims output_dims;
+
+    input_dims.n = DEPTHWISE_X_STRIDE_INPUT_BATCHES;
+    input_dims.w = DEPTHWISE_X_STRIDE_INPUT_W;
+    input_dims.h = DEPTHWISE_X_STRIDE_INPUT_H;
+    input_dims.c = DEPTHWISE_X_STRIDE_IN_CH;
+    filter_dims.w = DEPTHWISE_X_STRIDE_FILTER_X;
+    filter_dims.h = DEPTHWISE_X_STRIDE_FILTER_Y;
+    output_dims.w = DEPTHWISE_X_STRIDE_OUTPUT_W;
+    output_dims.h = DEPTHWISE_X_STRIDE_OUTPUT_H;
+    output_dims.c = DEPTHWISE_X_STRIDE_OUT_CH;
+
+    conv_params.padding.w = DEPTHWISE_X_STRIDE_PAD_X;
+    conv_params.padding.h = DEPTHWISE_X_STRIDE_PAD_Y;
+    conv_params.stride.w = DEPTHWISE_X_STRIDE_STRIDE_X;
+    conv_params.stride.h = DEPTHWISE_X_STRIDE_STRIDE_Y;
+    conv_params.dilation.w = DEPTHWISE_X_STRIDE_DILATION_X;
+    conv_params.dilation.h = DEPTHWISE_X_STRIDE_DILATION_Y;
+
+    conv_params.ch_mult = DEPTHWISE_X_STRIDE_CH_MULT;
+
+    conv_params.input_offset = DEPTHWISE_X_STRIDE_INPUT_OFFSET;
+    conv_params.output_offset = DEPTHWISE_X_STRIDE_OUTPUT_OFFSET;
+    conv_params.activation.min = DEPTHWISE_X_STRIDE_OUT_ACTIVATION_MIN;
+    conv_params.activation.max = DEPTHWISE_X_STRIDE_OUT_ACTIVATION_MAX;
+
+    const int32_t wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size(&conv_params, &input_dims, &filter_dims, &output_dims);
+    const int32_t dsp_wrapper_buf_size =
+        arm_depthwise_conv_wrapper_s8_get_buffer_size_dsp(&conv_params, &input_dims, &filter_dims, &output_dims);
+
+    TEST_ASSERT_EQUAL(wrapper_buf_size, dsp_wrapper_buf_size);
+#endif
 }


### PR DESCRIPTION
These are only intended to be used on host to get correct buffer size for Arm(R) Helium Architecture and processors with DSP extension.
