### PR TITLE
1xN conv update: Process multiple colums

### DIFF
--- a/Include/arm_nn_types.h
+++ b/Include/arm_nn_types.h
@@ -22,8 +22,8 @@
  * Description:  Public header file to contain the CMSIS-NN structs for the
  *               TensorFlowLite micro compliant functions
  *
- * $Date:        8 Februari 2023
- * $Revision:    V.2.4.0
+ * $Date:        8 March 2023
+ * $Revision:    V.2.5.0
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -46,6 +46,7 @@ typedef enum
     ARM_CMSIS_NN_SUCCESS = 0,        /**< No error */
     ARM_CMSIS_NN_ARG_ERROR = -1,     /**< One or more arguments are incorrect */
     ARM_CMSIS_NN_NO_IMPL_ERROR = -2, /**<  No implementation available */
+    ARM_CMSIS_NN_FAILURE = -3,       /**<  Logical error */
 } arm_cmsis_nn_status;
 
 /** CMSIS-NN object to contain the width and height of a tile */

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        13 Februari 2023
- * $Revision:    V.15.0.0
+ * $Date:        8 March 2023
+ * $Revision:    V.15.0.1
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -309,13 +309,13 @@ int8_t *arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
  * @param[in]  lhs                Pointer to the LHS input matrix
  * @param[in]  rhs                Pointer to the RHS input matrix
  * @param[in]  bias               Pointer to the bias vector. The length of this vector is equal to the number of
- * output columns (or RHS input rows)
+ *                                output columns (or RHS input rows)
  * @param[out] dst                Pointer to the output matrix with "m" rows and "n" columns
  * @param[in]  dst_multipliers    Pointer to the multipliers vector needed for the per-channel requantization.
  *                                The length of this vector is equal to the number of output columns (or RHS input
- * rows)
+ *                                rows)
  * @param[in]  dst_shifts         Pointer to the shifts vector needed for the per-channel requantization. The length
- * of this vector is equal to the number of output columns (or RHS input rows)
+ *                                of this vector is equal to the number of output columns (or RHS input rows)
  * @param[in]  lhs_rows           Number of LHS input rows
  * @param[in]  rhs_rows           Number of RHS input rows
  * @param[in]  rhs_cols           Number of LHS/RHS input columns
@@ -323,8 +323,7 @@ int8_t *arm_nn_mat_mul_core_4x_s8(const int32_t row_elements,
  * @param[in]  dst_offset         Offset to be applied the output result
  * @param[in]  activation_min     Minimum value to clamp down the output. Range : int8
  * @param[in]  activation_max     Maximum value to clamp up the output. Range : int8
- * @param[in]  rhs_cols_offset    Offset between input columns. Used to handle non-unity strides
- *                                Expected value : x * rhs_cols, where x >= 1
+ * @param[in]  lhs_cols_offset    Column offset between subsequent lhs_rows
  *
  * @return     The function returns <code>ARM_CMSIS_NN_SUCCESS</code>
  *
@@ -342,7 +341,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                                             const int32_t dst_offset,
                                             const int32_t activation_min,
                                             const int32_t activation_max,
-                                            const int32_t rhs_cols_offset);
+                                            const int32_t lhs_cols_offset);
 
 /**
  * @brief s8 Vector by Matrix (transposed) multiplication

--- a/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1_x_n_s8.c
  * Description:  s8 version of 1xN convolution using symmetric quantization.
  *
- * $Date:        30 January 2023
- * $Revision:    V.3.3.0
+ * $Date:        8 March 2023
+ * $Revision:    V.3.4.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -59,18 +59,18 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
                                           const cmsis_nn_dims *output_dims,
                                           int8_t *output_data)
 {
-    (void)bias_dims;
     arm_cmsis_nn_status status = ARM_CMSIS_NN_SUCCESS;
+    int32_t buffer_size = arm_convolve_1_x_n_s8_get_buffer_size(input_dims, filter_dims);
     /* The wrapper API is the ultimate reference for argument check */
-    if ((input_dims->h != 1) || (output_dims->w % 4 != 0) || conv_params->dilation.w != 1)
+    if ((input_dims->h != 1) || conv_params->dilation.w != 1 || (buffer_size != 0 && ctx->buf == NULL) ||
+        conv_params->stride.w == 0 || (conv_params->stride.w * input_dims->c % 4 != 0))
     {
         status = ARM_CMSIS_NN_ARG_ERROR;
         goto out;
     }
 
 #if defined(ARM_MATH_MVEI)
-    (void)ctx;
-
+    (void)bias_dims;
     const uint16_t input_x = input_dims->w;
     const uint16_t kernel_x = filter_dims->w;
     const uint16_t output_x = output_dims->w;
@@ -79,63 +79,108 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
     const uint16_t pad_x = conv_params->padding.w;
     const uint16_t stride_x = conv_params->stride.w;
 
-    int i_batch;
-    for (i_batch = 0; i_batch < input_dims->n; i_batch++)
+    // Total pad for dilation of 1
+    const int32_t total_pad = ((output_x - 1) * stride_x + kernel_x - input_x);
+    const int32_t asym_pad = total_pad % 2;
+
+    if (pad_x * 2 + asym_pad != total_pad)
     {
-        for (int i_out_x = 0; i_out_x <= (output_x - 4); i_out_x += 4)
+        return ARM_CMSIS_NN_FAILURE;
+    }
+
+    const int32_t right_pad_num = pad_x + asym_pad != 0 ? MAX(1, (pad_x + asym_pad + stride_x - 1) / stride_x) : 0;
+    const int32_t left_pad_num = pad_x != 0 ? MAX(1, (pad_x + stride_x - 1) / stride_x) : 0;
+    const int32_t no_pad_num = MAX(output_x - (right_pad_num + left_pad_num), 0);
+    if (right_pad_num + no_pad_num + left_pad_num != output_x)
+    {
+        return ARM_CMSIS_NN_FAILURE;
+    }
+
+    for (int i_batch = 0; i_batch < input_dims->n; i_batch++)
+    {
+        // Handle left padded sections
+        int32_t lhs_rows = left_pad_num;
+        const int32_t rhs_cols = kernel_x * input_dims->c;
+        const int32_t rhs_rows = output_dims->c;
+        const int32_t lhs_offset = input_ch * stride_x;
+
+        int32_t out_idx = 0;
+
+        for (int i = 0; i < lhs_rows; i++)
         {
-            int32_t input_begin_idx[4];
-            int32_t ker_begin_idx[4];
-            int32_t ker_end_idx[4];
+            const int32_t est_input_x_idx = stride_x * i - pad_x;
+            const int32_t ker_begin_idx = -est_input_x_idx;
 
-            for (int i = 0; i < 4; i++)
-            {
-                const int32_t est_input_x_idx = stride_x * (i_out_x + i) - pad_x;
-                input_begin_idx[i] = MAX(0, est_input_x_idx);
-                ker_begin_idx[i] = MAX(0, -est_input_x_idx);
-                ker_end_idx[i] = MIN(kernel_x, input_x - est_input_x_idx);
-            }
+            const int32_t actual_kernel_len = kernel_x - ker_begin_idx;
 
-            if ((ker_begin_idx[0] != 0) || (ker_end_idx[3] != kernel_x))
-            {
-                for (int i = 0; i < 4; i++)
-                {
-                    const int32_t actual_kernel_len = ker_end_idx[i] - ker_begin_idx[i];
-                    status = arm_nn_mat_mul_core_1x_s8(actual_kernel_len * input_ch,
-                                                       (kernel_x - actual_kernel_len) * input_ch,
-                                                       input_data + input_begin_idx[i] * input_ch,
-                                                       filter_data + (ker_begin_idx[i] * input_ch),
-                                                       output_ch,
-                                                       conv_params,
-                                                       quant_params,
-                                                       bias_data,
-                                                       output_data);
-                    output_data += output_ch;
-                }
-            }
-            else
-            {
-                output_data = arm_nn_mat_mul_core_4x_s8(kernel_x * input_ch,
-                                                        stride_x * input_ch,
-                                                        input_data + input_begin_idx[0] * input_ch,
-                                                        filter_data,
-                                                        output_ch,
-                                                        conv_params,
-                                                        quant_params,
-                                                        bias_data,
-                                                        output_data);
-            }
-
-            if (status != ARM_CMSIS_NN_SUCCESS || output_data == NULL)
-            {
-                return ARM_CMSIS_NN_NO_IMPL_ERROR;
-            }
+            status = arm_nn_mat_mul_core_1x_s8(actual_kernel_len * input_ch,
+                                               ker_begin_idx * input_ch,
+                                               input_data,
+                                               filter_data + (ker_begin_idx * input_ch),
+                                               output_ch,
+                                               conv_params,
+                                               quant_params,
+                                               bias_data,
+                                               output_data);
+            output_data += output_ch;
         }
 
+        out_idx += lhs_rows;
+        int32_t input_start = stride_x * lhs_rows - pad_x;
+
+        if (input_start < 0)
+        {
+            return ARM_CMSIS_NN_FAILURE;
+        }
+        /* Non padded elements */
+        input_start *= input_ch;
+        lhs_rows = no_pad_num;
+
+        arm_nn_mat_mult_nt_t_s8(input_data + input_start,
+                                filter_data,
+                                bias_data,
+                                output_data,
+                                quant_params->multiplier,
+                                quant_params->shift,
+                                lhs_rows,
+                                rhs_rows,
+                                rhs_cols,
+                                conv_params->input_offset,
+                                conv_params->output_offset,
+                                conv_params->activation.min,
+                                conv_params->activation.max,
+                                lhs_offset);
+
+        output_data += lhs_rows * rhs_rows;
+
+        /* Right padded elements */
+        out_idx += lhs_rows;
+        lhs_rows = output_x - out_idx;
+
+        if (lhs_rows < 0)
+        {
+            return ARM_CMSIS_NN_FAILURE;
+        }
+
+        for (int i = out_idx; i < output_x; i++)
+        {
+            const int32_t est_input_x_idx = stride_x * i - pad_x;
+            const int32_t ker_end_idx = MIN(kernel_x, input_x - est_input_x_idx);
+
+            status = arm_nn_mat_mul_core_1x_s8(ker_end_idx * input_ch,
+                                               (kernel_x - ker_end_idx) * input_ch,
+                                               input_data + est_input_x_idx * input_ch,
+                                               filter_data,
+                                               output_ch,
+                                               conv_params,
+                                               quant_params,
+                                               bias_data,
+                                               output_data);
+            output_data += output_ch;
+        }
         /* Advance to the next batch */
         input_data += (input_x * input_ch);
     }
-
 #else
     status = arm_convolve_s8(ctx,
                              conv_params,
@@ -148,6 +193,7 @@ arm_cmsis_nn_status arm_convolve_1_x_n_s8(const cmsis_nn_context *ctx,
                              bias_data,
                              output_dims,
                              output_data);
+
 #endif
 
 out:

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_get_buffer_sizes_s8.c
  * Description:  Collection of get buffer size functions for the various s8 convolution layer functions.
  *
- * $Date:        31 January 2023
- * $Revision:    V.1.0.0
+ * $Date:        8 March 2023
+ * $Revision:    V.1.1.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -98,7 +98,7 @@ int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params *conv
 #if defined(ARM_MATH_MVEI)
     return arm_convolve_wrapper_s8_get_buffer_size_mve(conv_params, input_dims, filter_dims, output_dims);
 #else
-
+    (void)output_dims;
     if ((conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
         (filter_dims->h == 1) && (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
     {
@@ -111,8 +111,8 @@ int32_t arm_convolve_wrapper_s8_get_buffer_size(const cmsis_nn_conv_params *conv
             return 0;
         }
     }
-    else if ((input_dims->h == 1) && (output_dims->w % 4 == 0) && (conv_params->dilation.w == 1) &&
-             (filter_dims->h == 1))
+    else if ((input_dims->h == 1) && (conv_params->dilation.w == 1) && (filter_dims->h == 1) &&
+             (conv_params->stride.w * input_dims->c % 4 == 0))
     {
         return arm_convolve_1_x_n_s8_get_buffer_size(input_dims, filter_dims);
     }
@@ -128,6 +128,7 @@ int32_t arm_convolve_wrapper_s8_get_buffer_size_mve(const cmsis_nn_conv_params *
                                                     const cmsis_nn_dims *filter_dims,
                                                     const cmsis_nn_dims *output_dims)
 {
+    (void)output_dims;
     if ((conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
         (filter_dims->h == 1) && (conv_params->dilation.w == 1 && conv_params->dilation.h == 1))
     {
@@ -140,8 +141,8 @@ int32_t arm_convolve_wrapper_s8_get_buffer_size_mve(const cmsis_nn_conv_params *
             return 0;
         }
     }
-    else if ((input_dims->h == 1) && (output_dims->w % 4 == 0) && (conv_params->dilation.w == 1) &&
-             (filter_dims->h == 1))
+    else if ((input_dims->h == 1) && (conv_params->dilation.w == 1) && (filter_dims->h == 1) &&
+             (conv_params->stride.w * input_dims->c % 4 == 0))
     {
         return arm_convolve_1_x_n_s8_get_buffer_size_mve(input_dims, filter_dims);
     }

--- a/Source/ConvolutionFunctions/arm_convolve_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_s8.c
  * Description:  s8 version of convolution using symmetric quantization.
  *
- * $Date:        7 January 2023
- * $Revision:    V.3.3.0
+ * $Date:        8 March 2023
+ * $Revision:    V.3.3.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -82,11 +82,13 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
     const uint16_t pad_y = conv_params->padding.h;
     const uint16_t stride_x = conv_params->stride.w;
     const uint16_t stride_y = conv_params->stride.h;
-
-    const int32_t input_offset = conv_params->input_offset;
+    const int32_t dilation_x = conv_params->dilation.w;
+    const int32_t dilation_y = conv_params->dilation.h;
     const int32_t out_offset = conv_params->output_offset;
     const int32_t out_activation_min = conv_params->activation.min;
     const int32_t out_activation_max = conv_params->activation.max;
+
+    const int32_t input_offset = conv_params->input_offset;
     int32_t *output_mult = quant_params->multiplier;
     int32_t *output_shift = quant_params->shift;
 
@@ -100,8 +102,6 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
         int32_t lhs_rows = 0;
         const int32_t rhs_rows = output_dims->c;
         const int32_t rhs_cols = kernel_x * kernel_y * input_ch;
-        const int32_t dilation_x = conv_params->dilation.w;
-        const int32_t dilation_y = conv_params->dilation.h;
 
         /* This part implements the im2col function */
         for (int i_out_y = 0; i_out_y < output_y; i_out_y++)
@@ -181,9 +181,6 @@ arm_cmsis_nn_status arm_convolve_s8(const cmsis_nn_context *ctx,
             im2col_buf = (int8_t *)buffer_a;
         }
 #else // #if defined(ARM_MATH_MVEI)
-        const uint16_t dilation_x = conv_params->dilation.w;
-        const uint16_t dilation_y = conv_params->dilation.h;
-
         int32_t i_out_y, i_out_x, i_ker_y, i_ker_x;
 
         /* Generate two columns from the input tensor a GEMM computation */

--- a/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
@@ -22,8 +22,8 @@
  * Description:  s8 convolution layer wrapper function with the main purpose to call the optimal kernel available in
  * cmsis-nn to perform the convolution.
  *
- * $Date:        11 January 2023
- * $Revision:    V.2.3.0
+ * $Date:        8 March 2023
+ * $Revision:    V.2.4.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -91,7 +91,8 @@ arm_cmsis_nn_status arm_convolve_wrapper_s8(const cmsis_nn_context *ctx,
                                        output_data);
         }
     }
-    else if ((input_dims->h == 1) && (output_dims->w % 4 == 0) && conv_params->dilation.w == 1 && (filter_dims->h == 1))
+    else if ((input_dims->h == 1) && conv_params->dilation.w == 1 && (filter_dims->h == 1) &&
+             ((conv_params->stride.w * input_dims->c) % 4 == 0))
     {
         return arm_convolve_1_x_n_s8(ctx,
                                      conv_params,

--- a/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_s8_nt_t_s8
  * Description:  Matrix multiplication support function with the right-hand-side (rhs) matrix transposed
  *
- * $Date:        7 March 2023
- * $Revision:    V.2.2.0
+ * $Date:        8 March 2023
+ * $Revision:    V.2.1.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -58,16 +58,10 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                                             const int32_t dst_offset,
                                             const int32_t activation_min,
                                             const int32_t activation_max,
-                                            const int32_t rhs_cols_offset)
+                                            const int32_t lhs_cols_offset)
 {
 
 #if defined(ARM_MATH_MVEI)
-
-    int8_t *out_ref = dst;
-    const int8_t *in_ref = lhs;
-    (void)out_ref;
-    (void)in_ref;
-    int32_t offset = rhs_cols_offset;
     int i_items = 0;
     for (; i_items <= (lhs_rows - 4); i_items += 4)
     {
@@ -79,9 +73,9 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             int32_t acc_n3 = 0;
 
             const int8_t *lhs_vec = lhs;
-            const int8_t *ip_row_1 = lhs + offset;
-            const int8_t *ip_row_2 = lhs + (2 * offset);
-            const int8_t *ip_row_3 = lhs + (3 * offset);
+            const int8_t *ip_row_1 = lhs + lhs_cols_offset;
+            const int8_t *ip_row_2 = lhs + (2 * lhs_cols_offset);
+            const int8_t *ip_row_3 = lhs + (3 * lhs_cols_offset);
             const int8_t *col_base = rhs + i * rhs_cols;
             int32_t sum_tmp = 0;
 
@@ -143,7 +137,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             vstrbq_scatter_offset_s32(dst, scatter_offset, res);
             dst++;
         }
-        lhs += 4 * offset;
+        lhs += 4 * lhs_cols_offset;
         dst += (3 * rhs_rows);
     }
 
@@ -203,7 +197,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 dst += 4;
             }
         }
-        lhs += offset;
+        lhs += lhs_cols_offset;
 
         for (int i = 0; i < (rhs_rows & 0x3); i++)
         {
@@ -217,8 +211,8 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
     }
 
 #elif defined(ARM_MATH_DSP)
-    const int32_t off0 = rhs_cols - 4;
-    const int32_t lhs_off0 = rhs_cols_offset - 4;
+    const int32_t rhs_off0 = rhs_cols - 4;
+    const int32_t lhs_off0 = lhs_cols_offset - 4;
 
     for (int32_t rhs_rows_idx = 0; rhs_rows_idx <= (rhs_rows - 2); rhs_rows_idx += 2)
     {
@@ -263,7 +257,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
-                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val1 = SXTB16_RORn(val1, 8);
                 val0 = SXTB16_RORn(val0, 8);
 
@@ -285,7 +279,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 res11 = SMLAD(val0, val4, res11);
 
-                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
@@ -310,7 +304,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 res11 = SMLAD(val0, val4, res11);
 
-                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
@@ -335,7 +329,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val1 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
                 res11 = SMLAD(val0, val4, res11);
 
-                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
@@ -366,7 +360,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 val2 = SXTB16(val1);
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
-                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val4 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val1 = SXTB16_RORn(val1, 8);
                 val0 = SXTB16_RORn(val0, 8);
 
@@ -397,7 +391,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 res00 += lhs_value * rhs_value0;
                 res01 += lhs_value * rhs_value1;
 
-                lhs_value = lhs_ptr[rhs_cols_offset];
+                lhs_value = lhs_ptr[lhs_cols_offset];
                 res10 += lhs_value * rhs_value0;
                 res11 += lhs_value * rhs_value1;
 
@@ -435,7 +429,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             dst_ptr += rhs_rows;
 
             lhs_ptr -= rhs_cols;
-            lhs_ptr += 2 * rhs_cols_offset;
+            lhs_ptr += 2 * lhs_cols_offset;
 
             lhs_rows_idx--;
         }
@@ -454,7 +448,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             for (; rhs_cols_idx <= (rhs_cols - 16); rhs_cols_idx += 16)
             {
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
                 val5 = SXTB16(val2);
@@ -470,7 +464,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 res01 = SMLAD(val2, val1, res01);
 
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
                 val5 = SXTB16(val2);
@@ -486,7 +480,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 res01 = SMLAD(val2, val1, res01);
 
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
                 val5 = SXTB16(val2);
@@ -502,7 +496,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 res01 = SMLAD(val2, val1, res01);
 
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
                 val5 = SXTB16(val2);
@@ -521,7 +515,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             for (; rhs_cols_idx <= (rhs_cols - 4); rhs_cols_idx += 4)
             {
                 val0 = arm_nn_read_s8x4_ia((const int8_t **)&rhs_ptr);
-                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[off0]);
+                val1 = arm_nn_read_s8x4((const int8_t *)&rhs_ptr[rhs_off0]);
                 val2 = arm_nn_read_s8x4_ia((const int8_t **)&lhs_ptr);
                 val3 = SXTB16(val0);
                 val5 = SXTB16(val2);
@@ -598,7 +592,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 ++lhs_ptr;
             }
             lhs_ptr -= rhs_cols;
-            lhs_ptr += rhs_cols_offset;
+            lhs_ptr += lhs_cols_offset;
 
             // Quantize down
             res00 = arm_nn_requantize(res00, dst_multipliers[rhs_rows - 1], dst_shifts[rhs_rows - 1]);
@@ -615,7 +609,6 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
         }
     }
 #else
-    (void)rhs_cols_offset;
     for (int32_t rhs_rows_idx = 0; rhs_rows_idx <= (rhs_rows - 2); rhs_rows_idx += 2)
     {
         const int8_t *lhs_ptr = &lhs[0];
@@ -658,7 +651,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 res00 += lhs_value * rhs_value0;
                 res01 += lhs_value * rhs_value1;
 
-                lhs_value = lhs_ptr[rhs_cols_offset];
+                lhs_value = lhs_ptr[lhs_cols_offset];
                 res10 += lhs_value * rhs_value0;
                 res11 += lhs_value * rhs_value1;
 
@@ -696,7 +689,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
             dst_ptr += rhs_rows;
 
             lhs_ptr -= rhs_cols;
-            lhs_ptr += 2 * rhs_cols_offset;
+            lhs_ptr += 2 * lhs_cols_offset;
 
             lhs_rows_idx--;
         }
@@ -769,7 +762,7 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
                 ++lhs_ptr;
             }
             lhs_ptr -= rhs_cols;
-            lhs_ptr += rhs_cols_offset;
+            lhs_ptr += lhs_cols_offset;
 
             // Quantize down
             res00 = arm_nn_requantize(res00, dst_multipliers[rhs_rows - 1], dst_shifts[rhs_rows - 1]);

--- a/Tests/UnitTest/TestCases/test_arm_convolve_1_x_n_s8/test_arm_convolve_1_x_n_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_1_x_n_s8/test_arm_convolve_1_x_n_s8.c
@@ -30,7 +30,7 @@
 
 void conv_1_x_n_1_arm_convolve_s8(void)
 {
-    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int8_t output[CONV_1_X_N_1_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -93,6 +93,7 @@ void conv_1_x_n_1_arm_convolve_s8(void)
         free(ctx.buf);
     }
     TEST_ASSERT_EQUAL(expected, result);
+    TEST_ASSERT_TRUE(validate(output, output_ref, output_ref_size));
     memset(output, 0, sizeof(output));
 
     buf_size = arm_convolve_s8_get_buffer_size(&input_dims, &filter_dims);
@@ -120,7 +121,7 @@ void conv_1_x_n_1_arm_convolve_s8(void)
 
 void conv_1_x_n_2_arm_convolve_s8(void)
 {
-    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int8_t output[CONV_1_X_N_2_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -391,7 +392,7 @@ void conv_1_x_n_4_arm_convolve_s8(void)
 
 void conv_1_x_n_5_arm_convolve_s8(void)
 {
-    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_ARG_ERROR;
+    const arm_cmsis_nn_status expected = ARM_CMSIS_NN_SUCCESS;
     int8_t output[CONV_1_X_N_5_DST_SIZE] = {0};
 
     cmsis_nn_context ctx;
@@ -555,7 +556,7 @@ void conv_1_x_n_6_arm_convolve_s8(void)
     TEST_ASSERT_EQUAL(ARM_CMSIS_NN_ARG_ERROR, result);
 
     conv_params.dilation.w = CONV_1_X_N_3_DILATION_X;
-    output_dims.w = CONV_1_X_N_3_OUTPUT_W + 1;
+    input_dims.c = CONV_1_X_N_3_IN_CH + 1;
 
     result = arm_convolve_1_x_n_s8(&ctx,
                                    &conv_params,


### PR DESCRIPTION
Process multiple columns at a time compared to
4 at a time. Revert to generic conv if unaligned
access is noticed for each stride_x step.

