### PR TITLE
Fix compiling with IAR

### DIFF
--- a/Include/Internal/arm_nn_compiler.h
+++ b/Include/Internal/arm_nn_compiler.h
@@ -21,8 +21,8 @@
  * Title:        arm_nn_compiler.h
  * Description:  Generic compiler header
  *
- * $Date:        09 August 2023
- * $Revision:    V.1.2.0
+ * $Date:        15 August 2023
+ * $Revision:    V.1.2.1
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -71,6 +71,9 @@
     #endif
     #ifndef __STATIC_FORCEINLINE
         #define __STATIC_FORCEINLINE __FORCEINLINE __STATIC_INLINE
+    #endif
+    #ifndef __RESTRICT
+        #define __RESTRICT __restrict
     #endif
 
 #elif defined(_MSC_VER)

--- a/Include/arm_nn_math_types.h
+++ b/Include/arm_nn_math_types.h
@@ -21,8 +21,8 @@
  * Title:        arm_nn_math_types.h
  * Description:  Compiler include and basic types
  *
- * $Date:        4 January 2023
- * $Revision:    V.1.3.2
+ * $Date:        15 August 2023
+ * $Revision:    V.1.3.3
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -52,7 +52,7 @@ extern "C" {
     #endif
 #endif
 
-#if defined(__ARM_FEATURE_MVE)
+#if (defined(__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE & 1))
     #ifndef ARM_MATH_MVEI
         #define ARM_MATH_MVEI 1
     #endif


### PR DESCRIPTION
__ARM_FEATURE_MVE is defined but set to zero on Cortex-M33, and presumably other non-MVE platforms. Check for bit 0 to be set, indicating integer MVE support. This is consistent with the __ARM_FEATURE_DSP check above.

__RESTRICT was missing from the IAR compiler abstraction.