### PR TITLE
Explicitly cast (void *) to (const int32_t *)

### DIFF
--- a/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
+++ b/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_fully_connected_s8
  * Description:  Fully connected function compatible with TF Lite.
  *
- * $Date:        13 January 2023
- * $Revision:    V.5.1.0
+ * $Date:        23 October 2023
+ * $Revision:    V.5.2.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -71,7 +71,7 @@ arm_cmsis_nn_status arm_fully_connected_s8(const cmsis_nn_context *ctx,
     }
 #endif
 
-    const int32_t *kernel_sum = ctx->buf;
+    const int32_t *kernel_sum = (const int32_t *) ctx->buf;
 
     while (batch_cnt)
     {


### PR DESCRIPTION
An implicit cast right there is the only reason CMSIS-NN can't be compiled with a C++ compiler.

I am aware this is a C project and not a C++ one but for my specific usecase I need to unfortunately compile it with a c++ compiler. Adding this patch to my fork works, and since it's a minor change that works in C just fine I wondered if you'd want this commit upstream.

Thanks for the great work!