### PR TITLE
Remove stack usage from int8 conv 1x1

### DIFF
--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        10 October 2023
- * $Revision:    V.17.2.0
+ * $Date:        27 October 2023
+ * $Revision:    V.17.2.1
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -375,8 +375,8 @@ arm_cmsis_nn_status arm_nn_mat_mult_nt_t_s8(const int8_t *lhs,
  *        This function assumes:
  *        - LHS input matrix NOT transposed (nt)
  *        - RHS input matrix transposed (t)
- *        - Number of LHS rows divisible by 3
- *        - Number of RHS rows divisible by 2
+ *        - Number of LHS rows multiple of 3
+ *        - Number of RHS rows multiple of 2
  *
  *  @note This operation assumes precomputing of the kernel sum
  *

--- a/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast s8 version of 1x1 convolution (non-square shape)
  *
- * $Date:        25 October 2023
- * $Revision:    V.3.4.0
+ * $Date:        27 October 2023
+ * $Revision:    V.3.3.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -74,7 +74,8 @@ arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
 
 #ifdef ARM_MATH_MVEI
 
-    if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0 && rhs_rows > lhs_rows * 4)
+    // Constraints on lhs_rows and rhs_rows follows from the implementation of arm_nn_mat_mult_nt_t_fast_s8
+    if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0)
     {
         if (ctx->buf == NULL)
         {

--- a/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_1x1_s8_fast.c
  * Description:  Fast s8 version of 1x1 convolution (non-square shape)
  *
- * $Date:        17 October 2023
- * $Revision:    V.3.3.0
+ * $Date:        25 October 2023
+ * $Revision:    V.3.4.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -65,7 +65,6 @@ arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
         return ARM_CMSIS_NN_ARG_ERROR;
     }
 
-    (void)ctx;
     (void)filter_dims;
     (void)bias_dims;
 
@@ -77,9 +76,13 @@ arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
 
     if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0 && rhs_rows > lhs_rows * 4)
     {
-        int32_t buf[rhs_rows];
-        int32_t *ker_sum = buf;
-        int32_t *buf_start = buf;
+        if (ctx->buf == NULL)
+        {
+            return ARM_CMSIS_NN_ARG_ERROR;
+        }
+
+        int32_t *ker_sum = ctx->buf;
+        int32_t *buf_start = ctx->buf;
 
         const int32_t lhs_offset = conv_params->input_offset;
 
@@ -123,6 +126,7 @@ arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
     else
 #endif
     {
+        (void)ctx;
         arm_nn_mat_mult_nt_t_s8(input_data,
                                 filter_data,
                                 bias_data,

--- a/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+++ b/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
@@ -75,7 +75,7 @@ arm_cmsis_nn_status arm_convolve_1x1_s8_fast(const cmsis_nn_context *ctx,
 #ifdef ARM_MATH_MVEI
 
     // Constraints on lhs_rows and rhs_rows follows from the implementation of arm_nn_mat_mult_nt_t_fast_s8
-    if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0)
+    if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0 && rhs_rows > lhs_rows * 4)
     {
         if (ctx->buf == NULL)
         {

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_get_buffer_sizes_s8.c
  * Description:  Collection of get buffer size functions for the various s8 convolution layer functions.
  *
- * $Date:        25 October 2023
- * $Revision:    V.1.4.0
+ * $Date:        27 October 2023
+ * $Revision:    V.1.3.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -67,7 +67,7 @@ __STATIC_INLINE int32_t arm_convolve_1x1_s8_fast_get_buffer_size_mve(const cmsis
 
     if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0 && rhs_rows > lhs_rows * 4)
     {
-        return rhs_rows * 4;
+        return rhs_rows * sizeof(int32_t);
     }
     else
     {

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_convolve_get_buffer_sizes_s8.c
  * Description:  Collection of get buffer size functions for the various s8 convolution layer functions.
  *
- * $Date:        09 October 2023
- * $Revision:    V.1.3.0
+ * $Date:        25 October 2023
+ * $Revision:    V.1.4.0
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -65,13 +65,13 @@ __STATIC_INLINE int32_t arm_convolve_1x1_s8_fast_get_buffer_size_mve(const cmsis
     const int32_t lhs_rows = input_dims->w * input_dims->h * input_dims->n;
     const int32_t rhs_rows = filter_dims->n;
 
-    if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0)
+    if (lhs_rows % 3 == 0 && rhs_rows % 2 == 0 && rhs_rows > lhs_rows * 4)
     {
-        return 0;
+        return rhs_rows * 4;
     }
     else
     {
-        return rhs_rows * 4;
+        return 0;
     }
 }
 

--- a/Tests/UnitTest/CMakeLists.txt
+++ b/Tests/UnitTest/CMakeLists.txt
@@ -28,7 +28,9 @@ add_compile_options(-Ofast
                     -Wimplicit-function-declaration
                     -Wunused-variable
                     -Wunused-function
-                    -Wno-redundant-decls)
+                    -Wno-redundant-decls
+                    -Wvla
+                    )
 
 option(BUILD_CMSIS_NN_UNIT "If building the unit tests from another project, i.e. \
 platform dependencies need to be provided externally." OFF)


### PR DESCRIPTION
Resolves bug issue #77
Additionally adds -Wvld flag to unit tests to catch similar bugs in the future.

Change-Id: I04a2b391d2252414a35ded93091a1aca394178ac