### PR TITLE
Add compiler optimization variable to CMake cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,13 @@
 #
 
 cmake_minimum_required(VERSION 3.15.6)
+set(CMSIS_OPTIMIZATION_LEVEL "-Ofast" CACHE STRING "Compiler optimization level.")
 
 project(CMSISNN)
 
 add_library(cmsis-nn STATIC)
 
-target_compile_options(cmsis-nn PRIVATE -Ofast)
+target_compile_options(cmsis-nn PRIVATE ${CMSIS_OPTIMIZATION_LEVEL})
 
 target_include_directories(cmsis-nn PUBLIC "Include")
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE=</path/to/ethos-u-core-platform>/cmake/toolchain
 ```
 
 ### Compiler Options
-Default optimization level is set at Ofast. Please change according to project needs. Just bear in mind this can impact
-performance. With only optimization level -O0, *ARM_MATH_AUTOVECTORIZE* needs to be defined for processors with Helium
+Default optimization level is set at Ofast. This can be overwritten with CMake on command line by using <nobr>*"-DCMSIS_OPTIMIZATION_LEVEL"*</nobr>. Please change according to project needs. 
+Just bear in mind this can impact performance. With only optimization level -O0, *ARM_MATH_AUTOVECTORIZE* needs to be defined for processors with Helium
 Technology.
 
 The compiler option *'-fomit-frame-pointer'* is enabled by default at -O and higher. When no optimization level is specified,

--- a/Tests/UnitTest/CMakeLists.txt
+++ b/Tests/UnitTest/CMakeLists.txt
@@ -22,13 +22,13 @@ project(cmsis_nn_unit_tests VERSION 0.0.1)
 
 set(CMSIS_PATH "</path/to/CMSIS>" CACHE PATH "Path to CMSIS.")
 
-add_compile_options(-Ofast
-                    -fomit-frame-pointer
+add_compile_options(-fomit-frame-pointer
                     -Werror
                     -Wimplicit-function-declaration
                     -Wunused-variable
                     -Wunused-function
-                    -Wno-redundant-decls)
+                    -Wno-redundant-decls
+                    -Wvla)
 
 option(BUILD_CMSIS_NN_UNIT "If building the unit tests from another project, i.e. \
 platform dependencies need to be provided externally." OFF)
@@ -51,6 +51,7 @@ endif()
 
 # Build the functions to be tested.
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../.. cmsis-nn)
+add_compile_options(${CMSIS_OPTIMIZATION_LEVEL})
 
 # Target for all unit tests.
 add_custom_target(cmsis_nn_unit_tests)


### PR DESCRIPTION
 * Replaces hard-coded -Ofast with cached -Ofast in target_compile_options

Change-Id: I91975416bfa2ed6d67c15ba36013b949cefc9065