### PR TITLE
Use legacy Keras 2.0 for test data generation

### DIFF
--- a/Tests/UnitTest/README.md
+++ b/Tests/UnitTest/README.md
@@ -33,7 +33,7 @@ Python packages mbed-cli and and mbed-ls are command line tools so it should not
 For generating new test data, the following packages are needed.
 
 ```
-pip install numpy packaging tensorflow
+pip install numpy packaging tensorflow tf-keras~=2.16
 ```
 
 

--- a/Tests/UnitTest/add_mul_settings.py
+++ b/Tests/UnitTest/add_mul_settings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -18,6 +18,7 @@ from test_settings import TestSettings
 
 import tensorflow as tf
 import numpy as np
+import tf_keras as keras
 
 
 class AddMulSettings(TestSettings):
@@ -90,16 +91,16 @@ class AddMulSettings(TestSettings):
             inttype_tf = tf.int8
 
         # Create a one-layer functional Keras model as add/mul cannot use a sequntial Keras model.
-        input1 = tf.keras.layers.Input(shape=input_shape[1:])
-        input2 = tf.keras.layers.Input(shape=input_shape[1:])
+        input1 = keras.layers.Input(shape=input_shape[1:])
+        input2 = keras.layers.Input(shape=input_shape[1:])
         if self.test_type == 'add':
-            layer = tf.keras.layers.Add()([input1, input2])
+            layer = keras.layers.Add()([input1, input2])
         elif self.test_type == 'mul':
-            layer = tf.keras.layers.Multiply()([input1, input2])
+            layer = keras.layers.Multiply()([input1, input2])
         else:
             raise RuntimeError("Wrong test type")
-        out = tf.keras.layers.Lambda(function=lambda x: x)(layer)
-        model = tf.keras.models.Model(inputs=[input1, input2], outputs=out)
+        out = keras.layers.Lambda(function=lambda x: x)(layer)
+        model = keras.models.Model(inputs=[input1, input2], outputs=out)
 
         interpreter = self.convert_and_interpret(model, inttype_tf)
 

--- a/Tests/UnitTest/conv_settings.py
+++ b/Tests/UnitTest/conv_settings.py
@@ -19,7 +19,7 @@ from test_settings import TestSettings
 import tensorflow as tf
 import numpy as np
 import math
-
+import tf_keras as keras
 
 class ConvSettings(TestSettings):
 
@@ -317,11 +317,11 @@ class ConvSettings(TestSettings):
                                                    regenerate=self.regenerate_new_weights)
 
             # Create a one layer Keras model.
-            model = tf.keras.models.Sequential()
+            model = keras.models.Sequential()
             input_shape = (self.batches, self.y_input, self.x_input, self.input_ch)
-            model.add(tf.keras.layers.InputLayer(input_shape=input_shape[1:], batch_size=self.batches))
+            model.add(keras.layers.InputLayer(input_shape=input_shape[1:], batch_size=self.batches))
             if self.test_type == 'conv':
-                conv_layer = tf.keras.layers.Conv2D(self.output_ch,
+                conv_layer = keras.layers.Conv2D(self.output_ch,
                                                     kernel_size=(self.filter_y, self.filter_x),
                                                     strides=(self.stride_y, self.stride_x),
                                                     padding=self.padding,
@@ -331,7 +331,7 @@ class ConvSettings(TestSettings):
                 model.add(conv_layer)
                 conv_layer.set_weights([weights, biases])
             elif self.test_type == 'depthwise_conv':
-                depthwise_layer = tf.keras.layers.DepthwiseConv2D(kernel_size=(self.filter_y, self.filter_x),
+                depthwise_layer = keras.layers.DepthwiseConv2D(kernel_size=(self.filter_y, self.filter_x),
                                                                   strides=(self.stride_y, self.stride_x),
                                                                   padding=self.padding,
                                                                   depth_multiplier=self.channel_multiplier,
@@ -340,7 +340,7 @@ class ConvSettings(TestSettings):
                 model.add(depthwise_layer)
                 depthwise_layer.set_weights([weights, biases])
             elif self.test_type == 'transpose_conv':
-                transposed_conv_layer = tf.keras.layers.Conv2DTranspose(self.output_ch,
+                transposed_conv_layer = keras.layers.Conv2DTranspose(self.output_ch,
                                                                         kernel_size=(self.filter_y, self.filter_x),
                                                                         strides=(self.stride_y, self.stride_x),
                                                                         padding=self.padding,
@@ -356,6 +356,9 @@ class ConvSettings(TestSettings):
 
             if self.test_type == 'transpose_conv' and self.generate_bias:
                 filter_index = 3
+                bias_index = 2
+            elif self.is_int16xint8 and self.generate_bias:
+                filter_index = 1
                 bias_index = 2
             else:
                 filter_index = 2

--- a/Tests/UnitTest/fully_connected_settings.py
+++ b/Tests/UnitTest/fully_connected_settings.py
@@ -18,7 +18,7 @@ from test_settings import TestSettings
 
 import tensorflow as tf
 import numpy as np
-
+import tf_keras as keras
 
 class FullyConnectedSettings(TestSettings):
 
@@ -226,11 +226,11 @@ class FullyConnectedSettings(TestSettings):
             weights_size = weights.numpy().size
 
             # Generate model in tensorflow with one fully_connected layer
-            model = tf.keras.models.Sequential()
+            model = keras.models.Sequential()
             model.add(
-                tf.keras.layers.InputLayer(input_shape=(self.y_input * self.x_input * self.input_ch, ),
+                keras.layers.InputLayer(input_shape=(self.y_input * self.x_input * self.input_ch, ),
                                            batch_size=self.batches))
-            fully_connected_layer = tf.keras.layers.Dense(self.output_ch, activation=None, use_bias=self.generate_bias)
+            fully_connected_layer = keras.layers.Dense(self.output_ch, activation=None, use_bias=self.generate_bias)
             model.add(fully_connected_layer)
             if self.generate_bias:
                 fully_connected_layer.set_weights([weights, biases])

--- a/Tests/UnitTest/generate_test_data.py
+++ b/Tests/UnitTest/generate_test_data.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 import os
+os.environ["TF_USE_LEGACY_KERAS"]="1"
 import sys
 import argparse
 

--- a/Tests/UnitTest/lstm_settings.py
+++ b/Tests/UnitTest/lstm_settings.py
@@ -19,7 +19,7 @@ from test_settings import TestSettings
 
 import tensorflow as tf
 import numpy as np
-
+import tf_keras as keras
 
 class LSTMSettings(TestSettings):
 
@@ -142,19 +142,19 @@ class LSTMSettings(TestSettings):
                                               maxrange=1.0)
 
         # Create a Keras based LSTM model.
-        input_layer = tf.keras.layers.Input(shape=(self.time_steps, self.number_inputs),
+        input_layer = keras.layers.Input(shape=(self.time_steps, self.number_inputs),
                                             batch_size=self.batches,
                                             name='input')
         if self.time_major:
             input_layer_transposed = tf.transpose(input_layer, perm=[1, 0, 2])
-            lstm_layer = tf.keras.layers.LSTM(units=self.number_units,
+            lstm_layer = keras.layers.LSTM(units=self.number_units,
                                               time_major=self.time_major,
                                               return_sequences=True)(input_layer_transposed)
         else:
-            lstm_layer = tf.keras.layers.LSTM(units=self.number_units,
+            lstm_layer = keras.layers.LSTM(units=self.number_units,
                                               time_major=self.time_major,
                                               return_sequences=True)(input_layer)
-        model = tf.keras.Model(input_layer, lstm_layer, name="LSTM")
+        model = keras.Model(input_layer, lstm_layer, name="LSTM")
 
         if self.time_major:
             time_major_offset = 1

--- a/Tests/UnitTest/pooling_settings.py
+++ b/Tests/UnitTest/pooling_settings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -18,7 +18,7 @@ from test_settings import TestSettings
 
 import numpy as np
 import tensorflow as tf
-
+import tf_keras as keras
 
 class PoolingSettings(TestSettings):
 
@@ -85,18 +85,18 @@ class PoolingSettings(TestSettings):
         input_data = tf.cast(input_data, tf.float32)
 
         # Create a one-layer Keras model
-        model = tf.keras.models.Sequential()
+        model = keras.models.Sequential()
         input_shape = (self.batches, self.y_input, self.x_input, self.input_ch)
-        model.add(tf.keras.layers.InputLayer(input_shape=input_shape[1:], batch_size=self.batches))
+        model.add(keras.layers.InputLayer(input_shape=input_shape[1:], batch_size=self.batches))
         if self.test_type == 'avgpool':
             model.add(
-                tf.keras.layers.AveragePooling2D(pool_size=(self.filter_y, self.filter_x),
+                keras.layers.AveragePooling2D(pool_size=(self.filter_y, self.filter_x),
                                                  strides=(self.stride_y, self.stride_x),
                                                  padding=self.padding,
                                                  input_shape=input_shape[1:]))
         elif self.test_type == 'maxpool':
             model.add(
-                tf.keras.layers.MaxPooling2D(pool_size=(self.filter_y, self.filter_x),
+                keras.layers.MaxPooling2D(pool_size=(self.filter_y, self.filter_x),
                                              strides=(self.stride_y, self.stride_x),
                                              padding=self.padding,
                                              input_shape=input_shape[1:]))

--- a/Tests/UnitTest/softmax_settings.py
+++ b/Tests/UnitTest/softmax_settings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,7 +17,7 @@
 import math
 from test_settings import TestSettings
 import tensorflow as tf
-
+import tf_keras as keras
 
 class SoftmaxSettings(TestSettings):
     softmax_input_integer_bits = 5
@@ -147,9 +147,9 @@ class SoftmaxSettings(TestSettings):
             output_data = interpreter.get_tensor(output_layer["index"])
         else:
             # Create a one-layer Keras model.
-            model = tf.keras.models.Sequential()
+            model = keras.models.Sequential()
             input_shape = (self.y_input, self.x_input)
-            model.add(tf.keras.layers.Softmax(input_shape=input_shape))
+            model.add(keras.layers.Softmax(input_shape=input_shape))
 
             interpreter = self.convert_and_interpret(model, inttype, tf.expand_dims(input_data, axis=0))
             output_details = interpreter.get_output_details()

--- a/Tests/UnitTest/test_settings.py
+++ b/Tests/UnitTest/test_settings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -26,7 +26,7 @@ from packaging import version
 
 import numpy as np
 import tensorflow as tf
-
+import tf_keras as keras
 
 class TestSettings(ABC):
 
@@ -453,8 +453,8 @@ class TestSettings(ABC):
         return self.interpret_model(input_data, inttype)
 
     def convert_model(self, model, inttype, dataset_shape=None):
-        model.compile(loss=tf.keras.losses.categorical_crossentropy,
-                      optimizer=tf.keras.optimizers.Adam(),
+        model.compile(loss=keras.losses.categorical_crossentropy,
+                      optimizer=keras.optimizers.Adam(),
                       metrics=['accuracy'])
         n_inputs = len(model.inputs)
 


### PR DESCRIPTION
Keras 3.0 is used by default since Tensorflow 2.16.1, and since this contains some breaking changes the scripts need to stay at 2.0