### PR TITLE
Add optional restrict keyword to conv core loop out pointers

### DIFF
--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        08 October 2024
- * $Revision:    V.22.4.0
+ * $Date:        04 November 2024
+ * $Revision:    V.22.5.0
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -71,6 +71,12 @@ extern "C" {
 // For input of int16 when number of columns are above this limit int64 accumulation is needed
 // to not loose precision.
 #define MAX_COL_COUNT (512)
+
+// By default this will have not effect. During compilation this may be set to __restrict, which may be beneficial for
+// performance. See README.md for more intformation.
+#ifndef OPTIONAL_RESTRICT_KEYWORD
+    #define OPTIONAL_RESTRICT_KEYWORD
+#endif
 
 /**
  * @brief definition to pack four 8 bit values.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The compiler option *'-fno-builtin'* does not utilize optimized implementations 
 
 Another option is to enable CMSIS_NN_USE_SINGLE_ROUNDING. This may affect the output. If enabling this the equivalent flag should be enabled in TFL/TFLM.
 
+For processors with DSP extension, int4 and int8 convolutions make use of the restrict keyword for the output pointer. This can allow the compiler to make optimizations but the actual performance result depends on the Arm(R) Cortex(R)-M processor, the compiler and the model. This optimization can be enabled by providing the compiler with a defition of OPTIONAL_RESTRICT_KEYWORD=__restrict . In general Arm Cortex-M7 will benefit from this. Similar Arm Cortex-M4 and Cortex-M33, will generally not benefit from it, but it may still bring an uplift depending on the model and compiler. It is recommended to enable this for Cortex-M7.
+
 ### Supported Compilers
 * CMSIS-NN is tested on Arm Compiler 6 and on Arm GNU Toolchain.
 * IAR compiler is not tested and there can be compilation and/or performance issues.

--- a/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s4_s16.c
+++ b/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s4_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_kernel_s4_s16.c
  * Description:  Matrix-multiplication function for convolution
  *
- * $Date:        01 November 2023
- * $Revision:    V.1.0.0
+ * $Date:        28 October 2024
+ * $Revision:    V.1.1.0
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -46,7 +46,7 @@ int8_t *arm_nn_mat_mult_kernel_s4_s16(const int8_t *packed_input_a,
                                       const int32_t activation_max,
                                       const int32_t num_col_a,
                                       const int32_t *const output_bias,
-                                      int8_t *out_0)
+                                      int8_t *OPTIONAL_RESTRICT_KEYWORD out_0)
 {
 
     /* set up the second output pointers */

--- a/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
+++ b/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,8 +21,8 @@
  * Title:        arm_nn_mat_mult_kernel_s8_s16.c
  * Description:  Matrix-multiplication function for convolution
  *
- * $Date:        29 May 2023
- * $Revision:    V.2.0.0
+ * $Date:        28 October 2024
+ * $Revision:    V.2.1.0
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -48,7 +48,7 @@ int8_t *arm_nn_mat_mult_kernel_s8_s16(const int8_t *input_a,
                                       const int32_t num_col_a,
                                       const int32_t aligned_num_col_a,
                                       const int32_t *const output_bias,
-                                      int8_t *out_0)
+                                      int8_t *OPTIONAL_RESTRICT_KEYWORD out_0)
 {
 #if !defined(ARM_MATH_MVEI)
     /* set up the second output pointers */


### PR DESCRIPTION
To enable it must be configured at build time.
It is disabled by default.
Updates README.