### PR TITLE
Optimize `arm_nn_requantize` for Thumb-2 processors

### DIFF
--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -22,7 +22,7 @@
  * Description:  Public header file of support functions for CMSIS NN Library
  *
  * $Date:        08 Nov 2024
- * $Revision:    V.22.7.0
+ * $Revision:    V.22.8.0
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -21,7 +21,7 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        08 Nov 2024
+ * $Date:        23 Apr 2025
  * $Revision:    V.22.8.0
  *
  * Target :  Arm(R) M-Profile Architecture

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -1526,7 +1526,7 @@ __STATIC_FORCEINLINE int32_t arm_nn_doubling_high_mult_no_sat(int32_t m1, int32_
                    "lsrs\t%1, %1, #31\n\t"
                    "adc\t%0, %1, %0, lsl #1\n\t"
                    : "+r"(m1), "+r"(m2) /* We also garble m2 */
-                   : 
+                   :
                    : "cc");
     return m1;
 #else
@@ -1567,7 +1567,8 @@ __STATIC_FORCEINLINE int32_t arm_nn_divide_by_power_of_two(const int32_t dividen
     // INT32_MIN can be encoded into the immediate of a CMP instruction.
     // I.e. this gives 3 instructions, no branch.
     int32_t temp = dividend;
-    if (temp < 0 && temp != INT32_MIN) {
+    if (temp < 0 && temp != INT32_MIN)
+    {
         temp--;
     }
     // INT32_MIN is even, so we do not depend on the decrement.
@@ -1632,10 +1633,13 @@ __STATIC_FORCEINLINE int32_t arm_nn_requantize(const int32_t val, const int32_t 
 
     return result;
 #elif defined(CMSIS_NN_USE_REQUANTIZE_INLINE_ASSEMBLY)
-    if (shift >= 0) {
+    if (shift >= 0)
+    {
         // left shift
         return arm_nn_doubling_high_mult_no_sat(val * (1 << shift), multiplier);
-    } else {
+    }
+    else
+    {
         // right shift
         return arm_nn_divide_by_power_of_two(arm_nn_doubling_high_mult_no_sat(val, multiplier), -shift);
     }

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -1632,8 +1632,13 @@ __STATIC_FORCEINLINE int32_t arm_nn_requantize(const int32_t val, const int32_t 
 
     return result;
 #else
-    return arm_nn_divide_by_power_of_two(arm_nn_doubling_high_mult_no_sat(val * (1 << LEFT_SHIFT(shift)), multiplier),
-                                         RIGHT_SHIFT(shift));
+    if (shift > 0) {
+        // left shift
+        return arm_nn_doubling_high_mult_no_sat(val * (1 << shift), multiplier);
+    } else {
+        // right shift
+        return arm_nn_divide_by_power_of_two(arm_nn_doubling_high_mult_no_sat(val, multiplier), -shift);
+    }
 #endif
 }
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,17 @@ you may need to specify '-fomit-frame-pointer'.
 
 The compiler option *'-fno-builtin'* does not utilize optimized implementations of e.g. memcpy and memset, which are heavily used by CMSIS-NN. It can significantly downgrade performance. So this should be avoided. The compiler option *'-ffreestanding'* should also be avoided as it enables '-fno-builtin' implicitly.
 
-Another option is to enable CMSIS_NN_USE_SINGLE_ROUNDING. This may affect the output. If enabling this the equivalent flag should be enabled in TFL/TFLM.
-
 For processors with DSP extension, int4 and int8 convolutions make use of the restrict keyword for the output pointer. This can allow the compiler to make optimizations but the actual performance result depends on the Arm(R) Cortex(R)-M processor, the compiler and the model. This optimization can be enabled by providing the compiler with a defition of OPTIONAL_RESTRICT_KEYWORD=__restrict . In general Arm Cortex-M7 will benefit from this. Similar Arm Cortex-M4 and Cortex-M33, will generally not benefit from it, but it may still bring an uplift depending on the model and compiler. It is recommended to enable this for Cortex-M7.
+
+Further compile-time options:
+
+| Name | Explanation | Affects headers(*) |
+|------|-----|-----|
+| CMSIS_NN_USE_SINGLE_ROUNDING | Use a single instead of double rounding in requantizazion. This may affect the output. | Yes |
+| CMSIS_NN_USE_REQUANTIZE_INLINE_ASSEMBLY | Use inline assembly for `arm_nn_requantize`. This code branch is faster on Cortex-M4, but slower on others. Results should be bit-identical, but was observed to cause differences with Arm Compiler and Cortex-M7. | Yes |
+
+(*) If you enable an option that affects headers, also enable the equivalent option in TFL/TFLM.
+
 
 ### Supported Compilers
 * CMSIS-NN is tested on Arm Compiler 6 and on Arm GNU Toolchain.


### PR DESCRIPTION
Rationale: According to my experience with e.g. the TFlite-micro examples, `arm_nn_requantize` is a non-negligible runtime consumer, easily responsible for 10-20% of all retired instructions.

Content:
This PR optimizes the three functions
- `arm_nn_doubling_high_mult_no_sat`,
- `arm_nn_divide_by_power_of_two`, and
- `arm_nn_requantize`,

in the standard "double rounding" code path. (Note: The code path for `CMSIS_NN_USE_SINGLE_ROUNDING` can be optimized using the same idea.)

The main idea is to shift only once and use the carry bit for rounding. The introduced code needs Thumb-2 instructions, consequently new code paths are added and guarded with `__ARM_ARCH_ISA_THUMB >= 2`, instead of replacing the existing ones. Hence, builds for Cortex-M0 and Cortex-M23 do *not* benefit from the optimizations. All other targets do.


Micro Benchmarks:
3x or 6x speedup, depending on the sign of the shift value.
Tested on an STM32 L4R5ZI with a Cortex-M4. (call overhead excluded, because the function will be inlined)
- Before this PR: 37 cycles per `arm_nn_requantize` call
- After this PR: 12 cycles per `arm_nn_requantize` call with negative value in `shift` argument
- After this PR: 6 cycles per `arm_nn_requantize` call with positive value in `shift` argument


Tests:
- I ran the unit tests with GCC on Corstone-300: `./build_and_run_tests.sh -c cortex-m0,cortex-m3,cortex-m4,cortex-m23,cortex-m33,cortex-m55`. All tests ran successfully.
- Additionally, I tested the individual functions with base-choice tests for bit identity in my own setup.


I do not have access to the Arm compiler. Therefore, there are still two open points. I would welcome support from anybody that has access to it:

Open points:
- Unit tests on Arm compiler.
- Feature test macro for Arm compiler (is it also `__ARM_ARCH_ISA_THUMB`?)
