### PR TITLE
Fix dispatch condition mismatch in convolve wrapper buffer size functions

### DIFF
--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,7 +22,7 @@
  * Description:  Public header file of support functions for CMSIS NN Library
  *
  * $Date:        27 Feb 2026
- * $Revision:    V.22.9.0
+ * $Revision:    V.22.8.1
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -43,28 +43,6 @@ extern "C" {
 #define USE_FAST_DW_CONV_S16_FUNCTION(dw_conv_params, filter_dims, input_dims)                                         \
     (dw_conv_params->ch_mult == 1 && dw_conv_params->dilation.w == 1 && dw_conv_params->dilation.h == 1 &&             \
      filter_dims->w * filter_dims->h < 512)
-
-__STATIC_INLINE bool arm_nn_is_convolve_1x1(const cmsis_nn_conv_params *conv_params,
-                                            const cmsis_nn_dims *input_dims,
-                                            const cmsis_nn_dims *filter_dims)
-{
-    return (conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
-        (filter_dims->h == 1) && (conv_params->dilation.w == 1) && (conv_params->dilation.h == 1) &&
-        (input_dims->c == filter_dims->c);
-}
-
-__STATIC_INLINE bool arm_nn_is_convolve_1x1_fast(const cmsis_nn_conv_params *conv_params)
-{
-    return (conv_params->stride.w == 1) && (conv_params->stride.h == 1);
-}
-
-__STATIC_INLINE bool arm_nn_is_convolve_1_x_n(const cmsis_nn_conv_params *conv_params,
-                                               const cmsis_nn_dims *input_dims,
-                                               const cmsis_nn_dims *filter_dims)
-{
-    return (input_dims->h == 1) && (conv_params->dilation.w == 1) && (filter_dims->h == 1) &&
-        ((conv_params->stride.w * input_dims->c) % 4 == 0) && (input_dims->c == filter_dims->c);
-}
 
 #define LEFT_SHIFT(_shift) (_shift > 0 ? _shift : 0)
 #define RIGHT_SHIFT(_shift) (_shift > 0 ? 0 : -_shift)
@@ -131,6 +109,49 @@ __STATIC_INLINE bool arm_nn_is_convolve_1_x_n(const cmsis_nn_conv_params *conv_p
  * Internal Support functions. Not intended to be called direclty by a CMSIS-NN user.
  *
  */
+
+/**
+ * @brief Check if convolution parameters correspond to a 1x1 convolution.
+ * @param[in]   conv_params   Convolution parameters
+ * @param[in]   input_dims    Input dimensions
+ * @param[in]   filter_dims   Filter dimensions
+ * @return      true if parameters describe a 1x1 convolution, false otherwise.
+ */
+__STATIC_INLINE bool arm_nn_is_convolve_1x1(const cmsis_nn_conv_params *conv_params,
+                                            const cmsis_nn_dims *input_dims,
+                                            const cmsis_nn_dims *filter_dims)
+{
+    return (conv_params->padding.w == 0) && (conv_params->padding.h == 0) && (filter_dims->w == 1) &&
+        (filter_dims->h == 1) && (conv_params->dilation.w == 1) && (conv_params->dilation.h == 1) &&
+        (input_dims->c == filter_dims->c);
+}
+
+/**
+ * @brief Check if a 1x1 convolution qualifies for the fast (unit stride) path.
+ * @param[in]   conv_params   Convolution parameters
+ * @return      true if stride is 1x1, false otherwise.
+ *
+ * @note Does not validate that the kernel is 1x1. Call arm_nn_is_convolve_1x1() first.
+ */
+__STATIC_INLINE bool arm_nn_is_convolve_1x1_fast(const cmsis_nn_conv_params *conv_params)
+{
+    return (conv_params->stride.w == 1) && (conv_params->stride.h == 1);
+}
+
+/**
+ * @brief Check if convolution parameters correspond to a 1xN convolution.
+ * @param[in]   conv_params   Convolution parameters
+ * @param[in]   input_dims    Input dimensions
+ * @param[in]   filter_dims   Filter dimensions
+ * @return      true if parameters describe a 1xN convolution, false otherwise.
+ */
+__STATIC_INLINE bool arm_nn_is_convolve_1_x_n(const cmsis_nn_conv_params *conv_params,
+                                              const cmsis_nn_dims *input_dims,
+                                              const cmsis_nn_dims *filter_dims)
+{
+    return (input_dims->h == 1) && (conv_params->dilation.w == 1) && (filter_dims->h == 1) &&
+        ((conv_params->stride.w * input_dims->c) % 4 == 0) && (input_dims->c == filter_dims->c);
+}
 
 /**
  * @defgroup genPrivTypes Structure Types

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s4.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s4.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,7 +22,7 @@
  * Description:  Collection of get buffer size functions for the various s4 convolution layer functions.
  *
  * $Date:        27 Feb 2026
- * $Revision:    V.1.2.0
+ * $Revision:    V.1.1.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_get_buffer_sizes_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,7 +22,7 @@
  * Description:  Collection of get buffer size functions for the various s8 convolution layer functions.
  *
  * $Date:        27 Feb 2026
- * $Revision:    V.2.3.0
+ * $Revision:    V.2.2.2
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_convolve_wrapper_s4.c
+++ b/Source/ConvolutionFunctions/arm_convolve_wrapper_s4.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,7 +23,7 @@
  *               cmsis-nn to perform the convolution. See header files for details.
  *
  * $Date:        27 Feb 2026
- * $Revision:    V.1.3.0
+ * $Revision:    V.1.2.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
+++ b/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -23,7 +23,7 @@
  * cmsis-nn to perform the convolution.
  *
  * $Date:        27 Feb 2026
- * $Revision:    V.2.6.0
+ * $Revision:    V.2.5.2
  *
  * Target :  Arm(R) M-Profile Architecture
  *

--- a/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s4_fast/test_arm_convolve_1x1_s4_fast.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s4_fast/test_arm_convolve_1x1_s4_fast.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/test_arm_convolve_1x1_s8_fast.c
+++ b/Tests/UnitTest/TestCases/test_arm_convolve_1x1_s8_fast/test_arm_convolve_1x1_s8_fast.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2010-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2010-2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
The convolve wrapper buffer size functions (pure-C, MVE, DSP variants) were missing the (input_dims->c == filter_dims->c) check present in the wrapper functions, causing buffer underallocation when input_dims->c != filter_dims->c.

Extract dispatch conditions into shared inline helpers in arm_nnsupportfunctions.h to keep wrapper and buffer size functions in sync. Apply helpers to both s8 and s4 wrapper and buffer size functions.

Fix arm_convolve_wrapper_s4_get_buffer_size MVE path to call the s4 buffer size variant instead of the s8 variant. Add missing filter_dims.c initialization in s8 and s4 1x1 fast buffer size unit tests, required by the shared helpers that check input_dims->c == filter_dims->c.