### PR TITLE
Fix MSVC build issues

### DIFF
--- a/Include/Internal/arm_nn_compiler.h
+++ b/Include/Internal/arm_nn_compiler.h
@@ -21,8 +21,8 @@
  * Title:        arm_nn_compiler.h
  * Description:  Generic compiler header
  *
- * $Date:        10 April 2025
- * $Revision:    V.1.3.1
+ * $Date:        28 April 2026
+ * $Revision:    V.1.3.2
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */
@@ -53,6 +53,9 @@
     #ifndef __RESTRICT
         #define __RESTRICT __restrict
     #endif
+    #ifndef UNUSED_ATTR
+        #define UNUSED_ATTR __attribute__((unused))
+    #endif
 
 #elif defined(__ICCARM__)
 
@@ -75,12 +78,15 @@
     #ifndef __RESTRICT
         #define __RESTRICT __restrict
     #endif
+    #ifndef UNUSED_ATTR
+        #define UNUSED_ATTR __attribute__((unused))
+    #endif
 
 #elif defined(_MSC_VER)
 
     // Build for non Arm Cortex-M processors is not tested or supported.
     // Use this section to stub any macros or intrinsics
-    #warning Unsupported compiler
+    #pragma message("Unsupported compiler")
     #ifndef __STATIC_FORCEINLINE
         #define __STATIC_FORCEINLINE static __forceinline
     #endif
@@ -90,6 +96,26 @@
     #ifndef __ALIGNED
         #define __ALIGNED(x) __declspec(align(x))
     #endif
+    #ifndef __RESTRICT
+        #define __RESTRICT __restrict
+    #endif
+    #ifndef UNUSED_ATTR
+        #define UNUSED_ATTR
+    #endif
+
+    #include "intrin.h"
+static inline unsigned clz_u32(unsigned long mask)
+{
+    unsigned long index;
+    if (_BitScanReverse(&index, mask))
+    {
+        return 31u - index;
+    }
+    // Return value of zero indicates no set bit found.
+    return 32u;
+}
+
+    #define CLZ(x) clz_u32((unsigned long)(x))
 
 #elif defined(__GNUC__)
 
@@ -107,6 +133,9 @@
     #endif
     #ifndef __RESTRICT
         #define __RESTRICT __restrict
+    #endif
+    #ifndef UNUSED_ATTR
+        #define UNUSED_ATTR __attribute__((unused))
     #endif
 
 #else

--- a/Source/Bindings/arm_py_transpose_conv_buffer_size.cpp
+++ b/Source/Bindings/arm_py_transpose_conv_buffer_size.cpp
@@ -21,14 +21,15 @@
  * Title:        arm_py_transpose_conv_buffer_size.cpp
  * Description:  Transpose convolution buffer size pybinds (optional Python module)
  *
- * $Date:        23 Feb 2026
- * $Revision:    V.1.0.0
+ * $Date:        29 Apr 2026
+ * $Revision:    V.1.1.0
  *
  * Target :  Host/Python
  * -------------------------------------------------------------------- */
 
 #include <array>
 #include <sstream>
+#include <string>
 
 #include "arm_py_common.hpp"
 
@@ -37,6 +38,16 @@ extern "C" {
 }
 
 namespace py = pybind11;
+
+/*
+ * Note that this pybind implementation differs from the others. This is due to the
+ * complex signature triggering error C1202 on MSVC (recursive type or function dependency context too complex)
+ * This is resolved by implementing the python calling semantics manually.
+ */
+
+// ----------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------
 
 static inline cmsis_nn_transpose_conv_params
 make_transpose_conv_params(const std::array<int32_t, 2> &padding_hw,
@@ -67,123 +78,259 @@ make_transpose_conv_params(const std::array<int32_t, 2> &padding_hw,
     return p;
 }
 
+static inline void throw_invalid_combo(Backend backend, DataType data_type)
+{
+    std::ostringstream msg;
+    msg << "invalid Backend/DataType combination: backend=" << static_cast<int>(backend)
+        << " data_type=" << static_cast<int>(data_type);
+    throw py::value_error(msg.str());
+}
+
+static inline bool is_valid_kwarg_name(const std::string &name, std::initializer_list<const char *> valid_names)
+{
+    for (const char *valid_name : valid_names)
+    {
+        if (name == valid_name)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static inline void
+validate_kwargs(const py::kwargs &kwargs, std::initializer_list<const char *> valid_names, const char *function_name)
+{
+    for (auto item : kwargs)
+    {
+        const std::string name = py::str(item.first).cast<std::string>();
+        if (!is_valid_kwarg_name(name, valid_names))
+        {
+            throw py::type_error(std::string(function_name) + "() got an unexpected keyword argument '" + name + "'");
+        }
+    }
+}
+
+template <typename T>
+static T parse_required_arg(const py::args &args, const py::kwargs &kwargs, size_t index, const char *name)
+{
+    const bool has_positional = index < args.size();
+    const bool has_keyword = kwargs.contains(name);
+
+    if (has_positional && has_keyword)
+    {
+        throw py::type_error(std::string("got multiple values for argument '") + name + "'");
+    }
+
+    if (has_positional)
+    {
+        return args[index].cast<T>();
+    }
+
+    if (has_keyword)
+    {
+        return kwargs[name].cast<T>();
+    }
+
+    throw py::type_error(std::string("missing required argument '") + name + "'");
+}
+
+template <typename T>
+static T parse_optional_arg(const py::args &args,
+                            const py::kwargs &kwargs,
+                            size_t index,
+                            const char *name,
+                            const T &default_value)
+{
+    const bool has_positional = index < args.size();
+    const bool has_keyword = kwargs.contains(name);
+
+    if (has_positional && has_keyword)
+    {
+        throw py::type_error(std::string("got multiple values for argument '") + name + "'");
+    }
+
+    if (has_positional)
+    {
+        return args[index].cast<T>();
+    }
+
+    if (has_keyword)
+    {
+        return kwargs[name].cast<T>();
+    }
+
+    return default_value;
+}
+
+// ----------------------------------------------------------------------
+// Wrapper implementations
+// ----------------------------------------------------------------------
+
+static int32_t transpose_conv_buffer_size_impl(Backend backend,
+                                               DataType data_type,
+                                               const std::array<int32_t, 4> &input_nhwc,
+                                               const std::array<int32_t, 4> &filter_nhwc,
+                                               const std::array<int32_t, 4> &output_nhwc,
+                                               const cmsis_nn_transpose_conv_params &params)
+{
+    switch (data_type)
+    {
+    case DataType::A8W8: {
+        const cmsis_nn_dims input_dims = make_dims(input_nhwc);
+        const cmsis_nn_dims filter_dims = make_dims(filter_nhwc);
+        const cmsis_nn_dims output_dims = make_dims(output_nhwc);
+
+        switch (backend)
+        {
+        case Backend::MVE:
+            return arm_transpose_conv_s8_get_buffer_size_mve(&params, &input_dims, &filter_dims, &output_dims);
+
+        case Backend::DSP:
+        case Backend::SCALAR:
+            return arm_transpose_conv_s8_get_buffer_size(&params, &input_dims, &filter_dims, &output_dims);
+        }
+        break;
+    }
+    }
+
+    throw_invalid_combo(backend, data_type);
+}
+
+static int32_t transpose_conv_reverse_conv_buffer_size_impl(Backend backend,
+                                                            DataType data_type,
+                                                            const std::array<int32_t, 4> &input_nhwc,
+                                                            const std::array<int32_t, 4> &filter_nhwc,
+                                                            const cmsis_nn_transpose_conv_params &params)
+{
+    switch (data_type)
+    {
+    case DataType::A8W8: {
+        const cmsis_nn_dims input_dims = make_dims(input_nhwc);
+        const cmsis_nn_dims filter_dims = make_dims(filter_nhwc);
+
+        switch (backend)
+        {
+        case Backend::MVE:
+        case Backend::DSP:
+        case Backend::SCALAR:
+            return arm_transpose_conv_s8_get_reverse_conv_buffer_size(&params, &input_dims, &filter_dims);
+        }
+        break;
+    }
+    }
+
+    throw_invalid_combo(backend, data_type);
+}
+
+static int32_t transpose_conv_buffer_size_py(py::args args, py::kwargs kwargs)
+{
+    constexpr size_t max_args = 13;
+    if (args.size() > max_args)
+    {
+        throw py::type_error("transpose_conv_buffer_size accepts at most 13 arguments");
+    }
+
+    validate_kwargs(kwargs,
+                    {"backend",
+                     "data_type",
+                     "input_nhwc",
+                     "filter_nhwc",
+                     "output_nhwc",
+                     "padding_hw",
+                     "stride_hw",
+                     "dilation_hw",
+                     "padding_offsets_hw",
+                     "input_offset",
+                     "output_offset",
+                     "activation_min",
+                     "activation_max"},
+                    "transpose_conv_buffer_size");
+
+    const Backend backend = parse_required_arg<Backend>(args, kwargs, 0, "backend");
+    const DataType data_type = parse_required_arg<DataType>(args, kwargs, 1, "data_type");
+    const auto input_nhwc = parse_required_arg<std::array<int32_t, 4>>(args, kwargs, 2, "input_nhwc");
+    const auto filter_nhwc = parse_required_arg<std::array<int32_t, 4>>(args, kwargs, 3, "filter_nhwc");
+    const auto output_nhwc = parse_required_arg<std::array<int32_t, 4>>(args, kwargs, 4, "output_nhwc");
+    const auto padding_hw = parse_required_arg<std::array<int32_t, 2>>(args, kwargs, 5, "padding_hw");
+    const auto stride_hw = parse_required_arg<std::array<int32_t, 2>>(args, kwargs, 6, "stride_hw");
+    const auto dilation_hw = parse_required_arg<std::array<int32_t, 2>>(args, kwargs, 7, "dilation_hw");
+    const auto padding_offsets_hw =
+        parse_optional_arg<std::array<int32_t, 2>>(args, kwargs, 8, "padding_offsets_hw", {0, 0});
+    const int32_t input_offset = parse_optional_arg<int32_t>(args, kwargs, 9, "input_offset", 0);
+    const int32_t output_offset = parse_optional_arg<int32_t>(args, kwargs, 10, "output_offset", 0);
+    const int32_t activation_min = parse_optional_arg<int32_t>(args, kwargs, 11, "activation_min", -128);
+    const int32_t activation_max = parse_optional_arg<int32_t>(args, kwargs, 12, "activation_max", 127);
+
+    const cmsis_nn_transpose_conv_params params = make_transpose_conv_params(padding_hw,
+                                                                             stride_hw,
+                                                                             dilation_hw,
+                                                                             padding_offsets_hw,
+                                                                             input_offset,
+                                                                             output_offset,
+                                                                             activation_min,
+                                                                             activation_max);
+
+    return transpose_conv_buffer_size_impl(backend, data_type, input_nhwc, filter_nhwc, output_nhwc, params);
+}
+
+static int32_t transpose_conv_reverse_conv_buffer_size_py(py::args args, py::kwargs kwargs)
+{
+    constexpr size_t max_args = 12;
+    if (args.size() > max_args)
+    {
+        throw py::type_error("transpose_conv_reverse_conv_buffer_size accepts at most 12 arguments");
+    }
+
+    validate_kwargs(kwargs,
+                    {"backend",
+                     "data_type",
+                     "input_nhwc",
+                     "filter_nhwc",
+                     "padding_hw",
+                     "stride_hw",
+                     "dilation_hw",
+                     "padding_offsets_hw",
+                     "input_offset",
+                     "output_offset",
+                     "activation_min",
+                     "activation_max"},
+                    "transpose_conv_reverse_conv_buffer_size");
+
+    const Backend backend = parse_required_arg<Backend>(args, kwargs, 0, "backend");
+    const DataType data_type = parse_required_arg<DataType>(args, kwargs, 1, "data_type");
+    const auto input_nhwc = parse_required_arg<std::array<int32_t, 4>>(args, kwargs, 2, "input_nhwc");
+    const auto filter_nhwc = parse_required_arg<std::array<int32_t, 4>>(args, kwargs, 3, "filter_nhwc");
+    const auto padding_hw = parse_required_arg<std::array<int32_t, 2>>(args, kwargs, 4, "padding_hw");
+    const auto stride_hw = parse_required_arg<std::array<int32_t, 2>>(args, kwargs, 5, "stride_hw");
+    const auto dilation_hw = parse_optional_arg<std::array<int32_t, 2>>(args, kwargs, 6, "dilation_hw", {1, 1});
+    const auto padding_offsets_hw =
+        parse_optional_arg<std::array<int32_t, 2>>(args, kwargs, 7, "padding_offsets_hw", {0, 0});
+    const int32_t input_offset = parse_optional_arg<int32_t>(args, kwargs, 8, "input_offset", 0);
+    const int32_t output_offset = parse_optional_arg<int32_t>(args, kwargs, 9, "output_offset", 0);
+    const int32_t activation_min = parse_optional_arg<int32_t>(args, kwargs, 10, "activation_min", -128);
+    const int32_t activation_max = parse_optional_arg<int32_t>(args, kwargs, 11, "activation_max", 127);
+
+    const cmsis_nn_transpose_conv_params params = make_transpose_conv_params(padding_hw,
+                                                                             stride_hw,
+                                                                             dilation_hw,
+                                                                             padding_offsets_hw,
+                                                                             input_offset,
+                                                                             output_offset,
+                                                                             activation_min,
+                                                                             activation_max);
+
+    return transpose_conv_reverse_conv_buffer_size_impl(backend, data_type, input_nhwc, filter_nhwc, params);
+}
+
+// ----------------------------------------------------------------------
+// Pybind module bindings
+// ----------------------------------------------------------------------
+
 void transpose_conv_buffer_size(py::module_ &m)
 {
-    m.def(
-        "transpose_conv_buffer_size",
-        [](Backend backend,
-           DataType data_type,
-           const std::array<int32_t, 4> &input_nhwc,
-           const std::array<int32_t, 4> &filter_nhwc,
-           const std::array<int32_t, 4> &output_nhwc,
-           const std::array<int32_t, 2> &padding_hw,
-           const std::array<int32_t, 2> &stride_hw,
-           const std::array<int32_t, 2> &dilation_hw,
-           const std::array<int32_t, 2> &padding_offsets_hw,
-           int32_t input_offset,
-           int32_t output_offset,
-           int32_t activation_min,
-           int32_t activation_max) -> int32_t {
-            switch (data_type)
-            {
-            case DataType::A8W8: {
-                const cmsis_nn_transpose_conv_params params = make_transpose_conv_params(padding_hw,
-                                                                                         stride_hw,
-                                                                                         dilation_hw,
-                                                                                         padding_offsets_hw,
-                                                                                         input_offset,
-                                                                                         output_offset,
-                                                                                         activation_min,
-                                                                                         activation_max);
+    m.def("transpose_conv_buffer_size", &transpose_conv_buffer_size_py);
 
-                const cmsis_nn_dims input_dims = make_dims(input_nhwc);
-                const cmsis_nn_dims filter_dims = make_dims(filter_nhwc);
-                const cmsis_nn_dims output_dims = make_dims(output_nhwc);
-
-                switch (backend)
-                {
-                case Backend::MVE:
-                    return arm_transpose_conv_s8_get_buffer_size_mve(&params, &input_dims, &filter_dims, &output_dims);
-                case Backend::DSP:
-                case Backend::SCALAR:
-                    return arm_transpose_conv_s8_get_buffer_size(&params, &input_dims, &filter_dims, &output_dims);
-                }
-                break;
-            }
-            }
-            std::ostringstream msg;
-            msg << "invalid Backend/DataType combination: backend=" << static_cast<int>(backend)
-                << " data_type=" << static_cast<int>(data_type);
-            throw py::value_error(msg.str());
-        },
-        py::arg("backend"),
-        py::arg("data_type"),
-        py::arg("input_nhwc"),
-        py::arg("filter_nhwc"),
-        py::arg("output_nhwc"),
-        py::arg("padding_hw"),
-        py::arg("stride_hw"),
-        py::arg("dilation_hw"),
-        py::arg("padding_offsets_hw") = std::array<int32_t, 2>{0, 0},
-        py::arg("input_offset") = 0,
-        py::arg("output_offset") = 0,
-        py::arg("activation_min") = -128,
-        py::arg("activation_max") = 127);
-
-    m.def(
-        "transpose_conv_reverse_conv_buffer_size",
-        [](Backend backend,
-           DataType data_type,
-           const std::array<int32_t, 4> &input_nhwc,
-           const std::array<int32_t, 4> &filter_nhwc,
-           const std::array<int32_t, 2> &padding_hw,
-           const std::array<int32_t, 2> &stride_hw,
-           const std::array<int32_t, 2> &dilation_hw,
-           const std::array<int32_t, 2> &padding_offsets_hw,
-           int32_t input_offset,
-           int32_t output_offset,
-           int32_t activation_min,
-           int32_t activation_max) -> int32_t {
-            switch (data_type)
-            {
-            case DataType::A8W8: {
-                const cmsis_nn_transpose_conv_params params = make_transpose_conv_params(padding_hw,
-                                                                                         stride_hw,
-                                                                                         dilation_hw,
-                                                                                         padding_offsets_hw,
-                                                                                         input_offset,
-                                                                                         output_offset,
-                                                                                         activation_min,
-                                                                                         activation_max);
-
-                const cmsis_nn_dims input_dims = make_dims(input_nhwc);
-                const cmsis_nn_dims filter_dims = make_dims(filter_nhwc);
-
-                switch (backend)
-                {
-                case Backend::MVE:
-                case Backend::DSP:
-                case Backend::SCALAR:
-                    return arm_transpose_conv_s8_get_reverse_conv_buffer_size(&params, &input_dims, &filter_dims);
-                }
-                break;
-            }
-            }
-            std::ostringstream msg;
-            msg << "invalid Backend/DataType combination: backend=" << static_cast<int>(backend)
-                << " data_type=" << static_cast<int>(data_type);
-            throw py::value_error(msg.str());
-        },
-        py::arg("backend"),
-        py::arg("data_type"),
-        py::arg("input_nhwc"),
-        py::arg("filter_nhwc"),
-        py::arg("padding_hw"),
-        py::arg("stride_hw"),
-        py::arg("dilation_hw"),
-        py::arg("padding_offsets_hw") = std::array<int32_t, 2>{0, 0},
-        py::arg("input_offset") = 0,
-        py::arg("output_offset") = 0,
-        py::arg("activation_min") = -128,
-        py::arg("activation_max") = 127);
+    m.def("transpose_conv_reverse_conv_buffer_size", &transpose_conv_reverse_conv_buffer_size_py);
 }

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_s16.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_s16.c
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_conv_s16.c
  * Description:  s16 version of depthwise convolution.
  *
- * $Date:        26 October 2022
- * $Revision:    V.2.0.1
+ * $Date:        28 April 2026
+ * $Revision:    V.2.0.2
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -40,27 +40,27 @@
  * @{
  */
 
-static void __attribute__((unused)) depthwise_conv_s16_mult_4_s16(const int16_t *input,
-                                                                  const int32_t input_x,
-                                                                  const int32_t input_y,
-                                                                  const int32_t input_ch,
-                                                                  const int8_t *kernel,
-                                                                  const int32_t output_ch,
-                                                                  const int32_t ch_mult,
-                                                                  const int32_t kernel_x,
-                                                                  const int32_t kernel_y,
-                                                                  const int32_t pad_x,
-                                                                  const int32_t pad_y,
-                                                                  const int32_t stride_x,
-                                                                  const int32_t stride_y,
-                                                                  const int64_t *bias,
-                                                                  int16_t *output,
-                                                                  const int32_t *output_shift,
-                                                                  const int32_t *output_mult,
-                                                                  const int32_t output_x,
-                                                                  const int32_t output_y,
-                                                                  const int32_t output_activation_min,
-                                                                  const int32_t output_activation_max)
+static void UNUSED_ATTR depthwise_conv_s16_mult_4_s16(const int16_t *input,
+                                                      const int32_t input_x,
+                                                      const int32_t input_y,
+                                                      const int32_t input_ch,
+                                                      const int8_t *kernel,
+                                                      const int32_t output_ch,
+                                                      const int32_t ch_mult,
+                                                      const int32_t kernel_x,
+                                                      const int32_t kernel_y,
+                                                      const int32_t pad_x,
+                                                      const int32_t pad_y,
+                                                      const int32_t stride_x,
+                                                      const int32_t stride_y,
+                                                      const int64_t *bias,
+                                                      int16_t *output,
+                                                      const int32_t *output_shift,
+                                                      const int32_t *output_mult,
+                                                      const int32_t output_x,
+                                                      const int32_t output_y,
+                                                      const int32_t output_activation_min,
+                                                      const int32_t output_activation_max)
 {
     for (int32_t in_h = -pad_y, out_h = 0, out_idx = 0; out_h < output_y; in_h += stride_y, ++out_h)
     {
@@ -91,7 +91,7 @@ static void __attribute__((unused)) depthwise_conv_s16_mult_4_s16(const int16_t 
                         int32_t ker_idx = ker_h * (output_ch * kernel_x) + ker_w_start * output_ch + out_ch;
                         int32_t in_idx = (in_h + ker_h) * (input_ch * input_x) + in_w * input_ch + in_ch;
 #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-#pragma clang loop unroll(disable)
+    #pragma clang loop unroll(disable)
 #endif
                         for (int32_t ker_w = ker_w_start; ker_w < MIN(kernel_x, input_x - in_w);
                              ++ker_w, ker_idx += output_ch)

--- a/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_depthwise_conv_s8.c
  * Description:  s8 version of depthwise convolution.
  *
- * $Date:        26 October 2022
- * $Revision:    V.3.0.4
+ * $Date:        28 April 2026
+ * $Revision:    V.3.0.5
  *
  * Target Processor:  Cortex-M CPUs
  *
@@ -40,7 +40,7 @@
  * @{
  */
 
-#if !defined(__ARMCC_VERSION)
+#if !(defined(__ARMCC_VERSION) || defined(_MSC_VER))
 __attribute__((optimize("no-unroll-loops")))
 #endif
 static void
@@ -100,7 +100,7 @@ depthwise_conv_s8_mult_4(const int8_t *input,
                         kernel = kernel_base + mult_tile + ker_idx;
                         int32_t in_idx = (in_h + ker_h) * (input_ch * input_x) + in_w * input_ch + in_ch;
 #if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-#pragma clang loop unroll(disable)
+    #pragma clang loop unroll(disable)
 #endif
                         for (int32_t ker_w = ker_w_start; ker_w < MIN(kernel_x, input_x - in_w);
                              ++ker_w, kernel += output_ch)


### PR DESCRIPTION
Fix MSVC-specific compiler compatibility in arm_nn_compiler.h by
- Replacing the unsupported compiler warning.
- Defining missing restrict/unused macros.
- Implement CLZ helper backed by intrin.h.

Refactor the transpose convolution pybind bindings to use wrapper functions instead of large lambdas
so the file builds with MSVC without triggering compiler error C1202.

Adjust depthwise convolution sources to use the portable UNUSED_ATTR acro and avoid applying the GCC-only optimize attribute when building with MSVC.

Note that this is a best-effort fix, and does not imply that MSVC is supported.