### PR TITLE
Fix integer overflow in single rounding requantization

### DIFF
--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -21,8 +21,8 @@
  * Title:        arm_nnsupportfunctions.h
  * Description:  Public header file of support functions for CMSIS NN Library
  *
- * $Date:        6 Mars 2026
- * $Revision:    V.22.9.0
+ * $Date:        21 May 2026
+ * $Revision:    V.22.9.1
  *
  * Target :  Arm(R) M-Profile Architecture
  * -------------------------------------------------------------------- */

--- a/Include/arm_nnsupportfunctions.h
+++ b/Include/arm_nnsupportfunctions.h
@@ -1683,7 +1683,7 @@ __STATIC_FORCEINLINE int32_t arm_nn_requantize(const int32_t val, const int32_t 
     const int64_t total_shift = 31 - shift;
     const int64_t new_val = val * (int64_t)multiplier;
 
-    int32_t result = new_val >> (total_shift - 1);
+    int64_t result = new_val >> (total_shift - 1);
     result = (result + 1) >> 1;
 
     return result;


### PR DESCRIPTION
### Problem

When `CMSIS_NN_USE_SINGLE_ROUNDING` is enabled, `arm_nn_requantize` suffered from an integer overflow. The intermediate value evaluated as `new_val >> (total_shift - 1)` can require up to 33 bits. Truncating this into an `int32_t` prematurely flipped the sign bit for large positive values, resulting in catastrophic output errors (e.g., yielding heavily negative numbers instead of saturated maximums).

### Solution

- Promoted the intermediate result variable from `int32_t` to `int64_t` to safely hold the 33-bit value.
- Moved the `int32_t` cast to the final return after the >> 1 shift has brought the value safely back into 32-bit bounds.
