### PR TITLE
Fix a bug in transpose_conv_s8 unit test.

### DIFF
--- a/Tests/UnitTest/TestCases/test_arm_transpose_conv_s8/Unity/unity_test_arm_transpose_conv_s8.c
+++ b/Tests/UnitTest/TestCases/test_arm_transpose_conv_s8/Unity/unity_test_arm_transpose_conv_s8.c
@@ -46,4 +46,4 @@ void tearDown(void) {}
 void test_transpose_conv_1_arm_transpose_conv_s8(void) { transpose_conv_1_arm_transpose_conv_s8(); }
 void test_transpose_conv_2_arm_transpose_conv_s8(void) { transpose_conv_2_arm_transpose_conv_s8(); }
 void test_transpose_conv_3_arm_transpose_conv_s8(void) { transpose_conv_3_arm_transpose_conv_s8(); }
-void test_transpose_conv_4_arm_transpose_conv_s8(void) { transpose_conv_3_arm_transpose_conv_s8(); }
+void test_transpose_conv_4_arm_transpose_conv_s8(void) { transpose_conv_4_arm_transpose_conv_s8(); }


### PR DESCRIPTION
The PR fixes a bug in transpose_conv_s8 unit test. test_transpose_conv_4_arm_transpose_conv_s8() shall call transpose_conv_4_arm_transpose_conv_s8() rather than transpose_conv_3_arm_transpose_conv_s8().