### PR TITLE
Using cmake.version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 [build-system]
-requires = ["scikit-build-core>=0.7", "pybind11>=2.10"]
+requires = ["scikit-build-core>=0.8,<1", "pybind11>=2.10,<3"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -25,7 +25,7 @@ description = "CMSIS-NN scratch buffer size get helpers."
 requires-python = ">=3.8"
 
 [tool.scikit-build]
-cmake.minimum-version = "3.15"
+cmake.version = ">=3.15"
 wheel.packages = ["python/cmsis_nn"]
 
 [tool.scikit-build.cmake.define]


### PR DESCRIPTION
* Replacing cmake.minimum-version with cmake-version in pyproject.toml
* This is due to a breaking change in scikit-build-core 1.0.0
* Also constraining scikit-build-core and pybind11 versions with an upper bound

Change-Id: Idbc65e726af3a6d19f509f7b4d05fa423f424a87