### PR TITLE
Bump cmake minimum required to 3.21 for ARMClang compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.15.6)
+cmake_minimum_required(VERSION 3.21)
 set(CMSIS_OPTIMIZATION_LEVEL
     "-Ofast"
     CACHE STRING "Compiler optimization level.")

--- a/Tests/UnitTest/CMakeLists.txt
+++ b/Tests/UnitTest/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.15.6)
+cmake_minimum_required(VERSION 3.21)
 
 project(cmsis_nn_unit_tests VERSION 0.0.1)
 


### PR DESCRIPTION
Selecting the newer CMake policy baseline enables CMP0123=NEW, which stops CMake from automatically deriving ARMClang architecture flags from CMAKE_SYSTEM_PROCESSOR and the undocumented CMAKE_SYSTEM_ARCH.

With the old policy behavior, CMake's ARMClang platform logic attempted to construct an -march option even when no architecture value was available, resulting in an invalid empty -march= flag with newer CMake.

Use the CMP0123 NEW behavior instead, leaving CPU/architecture selection to the toolchain and avoiding the invalid compiler option.
