### PR TITLE
Fix GCC optimization guards for Clang

### DIFF
--- a/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
+++ b/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
@@ -40,7 +40,7 @@
  * @{
  */
 
-#if !(defined(__ARMCC_VERSION) || defined(_MSC_VER))
+#if !(defined(__ARMCC_VERSION) || defined(_MSC_VER) || defined(__ICCARM__) || defined(__clang__))
 __attribute__((optimize("no-unroll-loops")))
 #endif
 static void

--- a/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_per_ch_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_per_ch_s8.c
@@ -52,7 +52,7 @@
  * Refer header file for details.
  *
  */
-#if !defined(ARM_MATH_MVEI) && defined(ARM_MATH_DSP) && !defined(__ARMCC_VERSION) && !defined(__ICCARM__)
+#if !defined(ARM_MATH_MVEI) && defined(ARM_MATH_DSP) && !defined(__ARMCC_VERSION) && !defined(__ICCARM__) && !defined(__clang__)
     #pragma GCC optimize("unroll-loops")
 #endif
 arm_cmsis_nn_status arm_nn_vec_mat_mult_t_per_ch_s8(const int8_t *lhs,

--- a/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
+++ b/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
@@ -52,7 +52,7 @@
  * Refer header file for details.
  *
  */
-#if !defined(ARM_MATH_MVEI) && defined(ARM_MATH_DSP) && !defined(__ARMCC_VERSION) && !defined(__ICCARM__)
+#if !defined(ARM_MATH_MVEI) && defined(ARM_MATH_DSP) && !defined(__ARMCC_VERSION) && !defined(__ICCARM__) && !defined(__clang__)
     #pragma GCC optimize("unroll-loops")
 #endif
 arm_cmsis_nn_status arm_nn_vec_mat_mult_t_s8(const int8_t *lhs,


### PR DESCRIPTION
Fixes #205

Clang defines `__GNUC__` for GCC compatibility, but it does not support the GCC-specific `optimize` attribute and `#pragma GCC optimize` used in these code paths.

This change excludes Clang from the GCC-only optimization hints and also adds the missing IAR guard for `arm_depthwise_conv_s8.c`.

Validation:
- Reproduced the Clang warnings for both the `optimize` attribute and `#pragma GCC optimize`.
- Verified the guards remain enabled for GCC.
- Verified the guards are disabled for Clang.
- Completed the official CMSIS-NN Cortex-M33 GCC build successfully.

