### PR TITLE
Fix transpose convolution scratch width for asymmetric strides

### DIFF
--- a/Source/ConvolutionFunctions/arm_transpose_conv_get_buffer_sizes_s8.c
+++ b/Source/ConvolutionFunctions/arm_transpose_conv_get_buffer_sizes_s8.c
@@ -21,8 +21,8 @@
  * Title:        arm_transpose_conv_get_buffer_sizes_s8.c
  * Description:  Collection of get buffer size functions for the transpose convolution layer functions.
  *
- * $Date:        9 Mars 2026
- * $Revision:    V.2.1.0
+ * $Date:        10 September 2026
+ * $Revision:    V.2.1.1
  *
  * Target :  Arm(R) M-Profile Architecture
  *
@@ -71,7 +71,7 @@ int32_t arm_transpose_conv_s8_get_buffer_size(const cmsis_nn_transpose_conv_para
     else
     {
         const int32_t buf_x = ((input_dims->w - 1) * transpose_conv_params->stride.w +
-                               MAX(filter_dims->w, transpose_conv_params->stride.h)) *
+                               MAX(filter_dims->w, transpose_conv_params->stride.w)) *
             out_dims->c;
         const int32_t buf_y = MAX(filter_dims->h, transpose_conv_params->stride.h);
         return buf_x * buf_y * sizeof(int32_t);
@@ -101,7 +101,7 @@ int32_t arm_transpose_conv_s8_get_buffer_size_mve(const cmsis_nn_transpose_conv_
     else
     {
         const int32_t buf_x = ((input_dims->w - 1) * transpose_conv_params->stride.w +
-                               MAX(filter_dims->w, transpose_conv_params->stride.h)) *
+                               MAX(filter_dims->w, transpose_conv_params->stride.w)) *
             out_dims->c;
         const int32_t buf_y = MAX(filter_dims->h, transpose_conv_params->stride.h);
         return buf_x * buf_y * sizeof(int32_t);

--- a/Tests/Bindings/test_transpose_conv_buffer_size.py
+++ b/Tests/Bindings/test_transpose_conv_buffer_size.py
@@ -38,6 +38,31 @@ from cmsis_nn import (
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.parametrize("backend", [Backend.SCALAR, Backend.DSP, Backend.MVE])
+@pytest.mark.parametrize(
+    "input_nhwc, filter_nhwc, output_nhwc, stride_hw, expected",
+    [
+        ((2, 1, 9, 4), (4, 1, 1, 4), (2, 1, 17, 4), (1, 2), 288),
+        ((1, 4, 5, 4), (3, 1, 1, 4), (1, 7, 5, 3), (2, 1), 120),
+        ((1, 4, 5, 4), (3, 1, 1, 4), (1, 4, 13, 3), (1, 3), 180),
+        ((1, 4, 5, 4), (3, 1, 1, 4), (1, 10, 5, 3), (3, 1), 180),
+        ((1, 4, 5, 4), (3, 3, 3, 4), (1, 6, 11, 3), (1, 2), 396),
+    ],
+)
+def test_transpose_conv_rolling_buffer_size(backend, input_nhwc, filter_nhwc, output_nhwc, stride_hw, expected):
+    size = transpose_conv_buffer_size(
+        backend,
+        DataType.A8W8,
+        input_nhwc=input_nhwc,
+        filter_nhwc=filter_nhwc,
+        output_nhwc=output_nhwc,
+        padding_hw=(0, 0),
+        stride_hw=stride_hw,
+        dilation_hw=(1, 1),
+    )
+    assert size == expected
+
+
 @pytest.mark.parametrize(
     "input_nhwc, filter_nhwc, output_nhwc, padding_hw, stride_hw, dilation_hw, padding_offsets_hw, input_offset, output_offset, activation_min, activation_max",
     [


### PR DESCRIPTION
The rolling-buffer width calculation in both transpose-convolution buffer-size functions uses `stride.h` in `MAX(filter_dims->w, ...)`. The execution kernel, `arm_transpose_conv_s8`, uses `stride.w`. This can underallocate scratch when the width stride exceeds both the height stride and filter width, and can overallocate when the height stride is larger.

For input NHWC `[2, 1, 9, 4]`, filter OHWI `[4, 1, 1, 4]`, output NHWC `[2, 1, 17, 4]`, and stride HW `[1, 2]`, the sizing API returns 272 bytes while the kernel initializes and resets 288 bytes. A guarded host execution against the original implementation overwrote 16 bytes beyond the reported allocation. The corrected size leaves the guard intact. This surfaced as output corruption in ExecuTorch when its memory planner placed a live output immediately after the scratch allocation.

Use the width stride in both sizing functions, matching the existing kernel. The execution kernel and reverse-convolution selection are unchanged. Add 15 binding regression cases covering asymmetric strides and a larger-filter control across scalar, DSP, and MVE backends.

Validation: all 23 tests in `Tests/Bindings` pass on the rebased branch, and the changed C file passes clang-format 18. The asymmetric-stride cases fail against the original sizing implementation. The same fix was also validated against ExecuTorch's previously pinned CMSIS-NN revision with an end-to-end Cortex-M55 reproducer, with and without Hardtanh; the focused ExecuTorch run had 51 passes and 9 existing expected failures.

Authored and validated with Codex assistance.